### PR TITLE
feat(core): add puppet and session events

### DIFF
--- a/core/index.ts
+++ b/core/index.ts
@@ -151,7 +151,12 @@ export default class Core {
   }
 
   private static checkForAutoShutdown(): void {
-    if (Core.wasManuallyStarted || this.connections.some(x => x.isActive())) return;
+    if (
+      Core.wasManuallyStarted ||
+      this.connections.some(x => x.isActive()) ||
+      Session.hasKeepAliveSessions()
+    )
+      return;
 
     Core.shutdown().catch(error => {
       log.error('Core.autoShutdown', {

--- a/core/injected-scripts/interactReplayer.ts
+++ b/core/injected-scripts/interactReplayer.ts
@@ -468,7 +468,7 @@ function createReplayItems() {
     return false;
   }
 
-  if (window.blockClickAndSubmit !== false) {
+  if (window.blockClickAndSubmit) {
     document.addEventListener('click', cancelEvent, true);
     document.addEventListener('submit', cancelEvent, true);
   }

--- a/core/test/resources.test.ts
+++ b/core/test/resources.test.ts
@@ -52,7 +52,7 @@ test('records a single resource for failed mitm requests', async () => {
   jest.spyOn(tab.puppetPage.networkManager, 'emit').mockImplementation((evt, args) => {
     // eslint-disable-next-line promise/always-return,promise/catch-or-return
     resolvable.promise.then(() => {
-      originalEmit(evt, args);
+      originalEmit(evt as any, args);
     });
     return true;
   });

--- a/interfaces/IPuppetPage.ts
+++ b/interfaces/IPuppetPage.ts
@@ -37,7 +37,7 @@ export interface IPuppetPage extends ITypedEventEmitter<IPuppetPageEvents> {
   popupInitializeFn?: (
     page: IPuppetPage,
     openParams: { url: string; windowName: string },
-  ) => Promise<void>;
+  ) => Promise<any>;
 
   setNetworkRequestInterceptor(
     networkRequestsFn: (
@@ -57,7 +57,7 @@ export interface IPuppetPage extends ITypedEventEmitter<IPuppetPageEvents> {
 }
 
 export interface IPuppetPageEvents extends IPuppetFrameManagerEvents, IPuppetNetworkEvents {
-  close: undefined;
+  close: void;
   worker: { worker: IPuppetWorker };
   crashed: { error: Error; fatal?: boolean };
   console: { frameId: string; type: string; message: string; location: string };

--- a/mitm/test/MitmRequestAgent.test.ts
+++ b/mitm/test/MitmRequestAgent.test.ts
@@ -168,7 +168,7 @@ test('should be able to handle a reused socket that closes on server', async () 
   httpRequestSpy.mockImplementationOnce(async (ctx, settings) => {
     serverSocket.destroy();
     await new Promise(setImmediate);
-    return await originalFn(ctx, settings);
+    return await originalFn(ctx as any, settings);
   });
 
   {

--- a/plugins/default-browser-emulator/injected-scripts/tsconfig.json
+++ b/plugins/default-browser-emulator/injected-scripts/tsconfig.json
@@ -11,7 +11,8 @@
     "resolveJsonModule": true,
     "sourceMap": false,
     "declaration": true,
-    "allowJs": true
+    "allowJs": true,
+    "strictBindCallApply": false
   },
   "references": [],
   "include": ["*.ts", "*.js", ".eslintrc.js"],

--- a/puppet-chrome/lib/Page.ts
+++ b/puppet-chrome/lib/Page.ts
@@ -51,7 +51,7 @@ export class Page extends TypedEventEmitter<IPuppetPageEvents> implements IPuppe
   public popupInitializeFn?: (
     page: IPuppetPage,
     openParams: { url: string; windowName: string },
-  ) => Promise<void>;
+  ) => Promise<any>;
 
   public devtoolsSession: DevtoolsSession;
   public targetId: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "declaration": true,
     "moduleResolution": "node",
     "skipLibCheck": true,
+    "strictBindCallApply": true,
     "resolveJsonModule": true,
     "allowJs": true,
     "rootDir": ".",


### PR DESCRIPTION
Add events to Core:
- GlobalPool: 'session-created', 'browser-launched'
- Session: 'tab-created'

Add more reliable shutdown for keep-alive sessions

Ts: enable strict bind apply to typecheck bind calls