### PR TITLE
feat(puppet): always kill chrome on shutdown

### DIFF
--- a/puppet/lib/launchProcess.ts
+++ b/puppet/lib/launchProcess.ts
@@ -22,6 +22,7 @@ import Log from '@ulixee/commons/lib/Logger';
 import ILaunchedProcess from '@ulixee/hero-interfaces/ILaunchedProcess';
 import Resolvable from '@ulixee/commons/lib/Resolvable';
 import * as Fs from 'fs';
+import ShutdownHandler from '@ulixee/commons/lib/ShutdownHandler';
 import { WebSocketTransport } from './WebSocketTransport';
 
 const { log } = Log(module);
@@ -108,6 +109,8 @@ export default async function launchProcess(
   });
 
   const wsEndpoint = await websocketEndpointResolvable.promise;
+  process.on('uncaughtExceptionMonitor', () => close());
+  ShutdownHandler.register(close);
   transport = new WebSocketTransport(wsEndpoint);
   await transport.waitForOpen;
 


### PR DESCRIPTION
Makes sure chrome is always killed when the process is about to exit (instead of doing a graceful shutdown)