### PR TITLE
fix(plugins): headed viewports

### DIFF
--- a/core/lib/Session.ts
+++ b/core/lib/Session.ts
@@ -155,17 +155,7 @@ export default class Session extends TypedEventEmitter<{
     this.plugins.configure(options);
     this.timezoneId = options.timezoneId || '';
     this.locale = options.locale;
-    this.viewport =
-      options.viewport ||
-      ({
-        positionX: 0,
-        positionY: 0,
-        screenWidth: 1440,
-        screenHeight: 900,
-        width: 1440,
-        height: 900,
-        deviceScaleFactor: 1,
-      } as IViewport);
+    this.viewport = options.viewport;
 
     this.sessionState = new SessionState(
       this.id,
@@ -582,9 +572,7 @@ export default class Session extends TypedEventEmitter<{
     return false;
   }
 
-  public static sessionsWithBrowserEngine(
-    isEngineMatch: (engine: IBrowserEngine) => boolean,
-  ): Session[] {
-    return Object.values(this.byId).filter(x => isEngineMatch(x.browserEngine));
+  public static sessionsWithBrowserId(browserId: string): Session[] {
+    return Object.values(this.byId).filter(x => x.browserContext?.browserId === browserId);
   }
 }

--- a/interfaces/ICorePlugin.ts
+++ b/interfaces/ICorePlugin.ts
@@ -109,10 +109,7 @@ export interface IBrowserEmulator extends ICorePlugin {
 }
 
 export interface IBrowserEmulatorMethods {
-  configure?(
-    options: IBrowserEmulatorConfig,
-    sessionSummary?: ISessionSummary,
-  ): Promise<any> | void;
+  configure?(options: IBrowserEmulatorConfig, sessionSummary?: ISessionSummary): void;
 
   onBrowserLaunchConfiguration?(launchArguments: string[]): Promise<any> | void;
 

--- a/interfaces/IViewport.ts
+++ b/interfaces/IViewport.ts
@@ -6,4 +6,5 @@ export default interface IViewport {
   screenHeight?: number;
   positionX?: number;
   positionY?: number;
+  isDefault?: boolean;
 }

--- a/plugins/default-browser-emulator/lib/Viewports.ts
+++ b/plugins/default-browser-emulator/lib/Viewports.ts
@@ -53,7 +53,8 @@ export default class Viewports {
       screenHeight,
       width: windowWidth,
       height: windowHeight,
-      deviceScaleFactor: 1,
+      deviceScaleFactor: 0,
+      isDefault: true,
     } as IViewport;
   }
 }

--- a/plugins/default-browser-emulator/lib/helpers/setScreensize.ts
+++ b/plugins/default-browser-emulator/lib/helpers/setScreensize.ts
@@ -1,18 +1,20 @@
 import IDevtoolsSession from '@ulixee/hero-interfaces/IDevtoolsSession';
 import { IPuppetPage } from '@ulixee/hero-interfaces/IPuppetPage';
+import { ISessionSummary } from '@ulixee/hero-interfaces/ICorePlugin';
 import BrowserEmulator from '../../index';
 
 export default async function setScreensize(
   emulator: BrowserEmulator,
   page: IPuppetPage,
   devtools: IDevtoolsSession,
+  sessionMeta: ISessionSummary,
 ): Promise<void> {
   const { viewport } = emulator;
   if (!viewport) return;
 
   const promises: Promise<any>[] = [];
 
-  if (emulator.browserEngine.isHeaded) {
+  if (emulator.browserEngine.isHeaded && viewport.screenWidth) {
     promises.push(
       page.devtoolsSession.send('Browser.getWindowForTarget').then(({ windowId, bounds }) => {
         if (bounds.width === viewport.width && bounds.height === viewport.height) {
@@ -22,6 +24,8 @@ export default async function setScreensize(
         return devtools.send('Browser.setWindowBounds', {
           windowId,
           bounds: {
+            left: viewport.positionX,
+            top: viewport.positionY,
             width: viewport.screenWidth,
             height: viewport.screenHeight + 20,
             windowState: 'normal',
@@ -31,17 +35,21 @@ export default async function setScreensize(
     );
   }
 
-  promises.push(
-    devtools.send('Emulation.setDeviceMetricsOverride', {
-      width: viewport.width,
-      height: viewport.height,
-      deviceScaleFactor: viewport.deviceScaleFactor ?? 1,
-      positionX: viewport.positionX,
-      positionY: viewport.positionY,
-      screenWidth: viewport.screenWidth,
-      screenHeight: viewport.screenHeight,
-      mobile: false,
-    }),
-  );
+  const ignoreViewport =
+    sessionMeta.options?.showBrowserInteractions === true && viewport.isDefault;
+  if (!ignoreViewport) {
+    promises.push(
+      devtools.send('Emulation.setDeviceMetricsOverride', {
+        width: viewport.width,
+        height: viewport.height,
+        deviceScaleFactor: viewport.deviceScaleFactor ?? 0,
+        positionX: viewport.positionX,
+        positionY: viewport.positionY,
+        screenWidth: viewport.screenWidth,
+        screenHeight: viewport.screenHeight,
+        mobile: false,
+      }),
+    );
+  }
   await Promise.all(promises);
 }


### PR DESCRIPTION
This PR turns off viewport emulation when the user requests to showBrowserInteractions in headed mode. This addresses two issues:
1) Viewport Emulation was hiding the fixed bar at the bottom of the page that shows commands
2) Resets "deviceScale" to 0 (meaning don't change). Was impacting use of retina on macs