### PR TITLE
Default context

### DIFF
--- a/core/injected-scripts/interactReplayer.ts
+++ b/core/injected-scripts/interactReplayer.ts
@@ -166,7 +166,7 @@ function clearHighlights() {
 
 function highlightNodes(nodes: IHighlightedNodes) {
   if (nodes === undefined) return;
-  if (nodes && nodes?.frameIdPath !== window.selfFrameIdPath) {
+  if (nodes && nodes.frameIdPath && nodes.frameIdPath !== window.selfFrameIdPath) {
     clearHighlights();
     // delegate to subframe
     delegateInteractToSubframe(nodes, 'highlight');

--- a/core/lib/CommandRunner.ts
+++ b/core/lib/CommandRunner.ts
@@ -7,6 +7,11 @@ export default class CommandRunner {
     const [targetName, method] = command.split('.');
 
     if (!targets[targetName]) {
+      if (method === 'close' || (targetName === 'Events' && args[1] === 'close')) {
+        this.runFn = () => Promise.resolve({});
+        return;
+      }
+
       throw new Error(`Target for command not available (${targetName})`);
     }
 

--- a/core/lib/GlobalPool.ts
+++ b/core/lib/GlobalPool.ts
@@ -158,6 +158,7 @@ export default class GlobalPool {
           sessionId: session.id,
         }),
         session.getMitmProxy(),
+        session.useIncognitoContext(),
       );
       await session.initialize(browserContext);
 

--- a/core/lib/Interactor.ts
+++ b/core/lib/Interactor.ts
@@ -531,7 +531,7 @@ export function isMousePositionCoordinate(value: IMousePosition): boolean {
     Array.isArray(value) &&
     value.length === 2 &&
     typeof value[0] === 'number' &&
-    typeof value[0] === 'number'
+    typeof value[1] === 'number'
   );
 }
 

--- a/core/lib/Session.ts
+++ b/core/lib/Session.ts
@@ -294,12 +294,17 @@ export default class Session
     };
   }
 
+  public useIncognitoContext(): boolean {
+    const options = this.options;
+    return !(options.showBrowser === true && options.sessionKeepAlive === true);
+  }
+
   public async registerWithMitm(
     sharedMitmProxy: MitmProxy,
     doesPuppetSupportBrowserContextProxy: boolean,
   ): Promise<void> {
     let mitmProxy = sharedMitmProxy;
-    if (doesPuppetSupportBrowserContextProxy) {
+    if (doesPuppetSupportBrowserContextProxy && this.useIncognitoContext()) {
       this.isolatedMitmProxy = await MitmProxy.start(GlobalPool.localProxyPortStart, Core.dataDir);
       mitmProxy = this.isolatedMitmProxy;
     }

--- a/core/test/connection.test.ts
+++ b/core/test/connection.test.ts
@@ -4,10 +4,10 @@ import * as http from 'http';
 import { Log } from '@ulixee/commons/lib/Logger';
 import BrowserEmulator from '@ulixee/default-browser-emulator';
 import { DependenciesMissingError } from '@ulixee/chrome-app/lib/DependenciesMissingError';
-import { DependencyInstaller } from '@ulixee/chrome-app/lib/DependencyInstaller';
 import ChromeApp from '@ulixee/chrome-app/index';
+import BrowserEngine from '@ulixee/hero-plugin-utils/lib/BrowserEngine';
 
-const validate = jest.spyOn(DependencyInstaller.prototype, 'validate');
+const validate = jest.spyOn(BrowserEngine.prototype, 'verifyLaunchable');
 const logError = jest.spyOn(Log.prototype, 'error');
 
 let httpServer: Helpers.ITestHttpServer<http.Server>;
@@ -80,7 +80,7 @@ describe('basic connection tests', () => {
 
     logError.mockClear();
     validate.mockClear();
-    validate.mockImplementationOnce(() => {
+    validate.mockImplementationOnce(async () => {
       throw new DependenciesMissingError(
         `You can resolve this by running the apt dependency installer at:${ChromeApp.aptScriptPath}`,
         'Chrome',

--- a/fullstack/test/emulate.test.ts
+++ b/fullstack/test/emulate.test.ts
@@ -4,7 +4,10 @@ import { GlobalPool } from '@ulixee/hero-core';
 import { ITestKoaServer } from '@ulixee/hero-testing/helpers';
 import Resolvable from '@ulixee/commons/lib/Resolvable';
 import Viewports from '@ulixee/default-browser-emulator/lib/Viewports';
+import { latestChromeBrowserVersion } from '@ulixee/default-browser-emulator';
 import Hero from '../index';
+
+const chromeVersion = latestChromeBrowserVersion.major;
 
 let koaServer: ITestKoaServer;
 beforeAll(async () => {
@@ -190,7 +193,8 @@ describe('geolocation', () => {
     Helpers.needsClosing.push(hero);
     await hero.goto(koaServer.baseUrl);
 
-    const geolocation = await hero.getJsValue(`new Promise(resolve => navigator.geolocation.getCurrentPosition(position => {
+    const geolocation =
+      await hero.getJsValue(`new Promise(resolve => navigator.geolocation.getCurrentPosition(position => {
         resolve({ latitude: position.coords.latitude, longitude: position.coords.longitude });
       }))`);
     expect(geolocation).toEqual({
@@ -204,8 +208,7 @@ describe('user hero and platform', () => {
   const propsToGet = `appVersion, platform, userAgent, deviceMemory`.split(',').map(x => x.trim());
 
   it('should be able to configure a userAgent', async () => {
-    const userAgent =
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4472.124 Safari/537.36';
+    const userAgent = `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${chromeVersion}.0.4389.114 Safari/537.36`;
     const hero = new Hero({
       userAgent,
     });
@@ -217,7 +220,7 @@ describe('user hero and platform', () => {
 
   it('should be able to configure a userAgent with a range', async () => {
     const hero = new Hero({
-      userAgent: '~ chrome >= 88 && chrome < 89',
+      userAgent: `~ chrome >= ${chromeVersion} && chrome < ${Number(chromeVersion) + 1}`,
     });
     Helpers.needsClosing.push(hero);
 
@@ -225,12 +228,12 @@ describe('user hero and platform', () => {
     const chromeMatch = heroMeta.userAgentString.match(/Chrome\/(\d+)/);
     expect(chromeMatch).toBeTruthy();
     const version = Number(chromeMatch[1]);
-    expect(version).toBe(88);
+    expect(version).toBe(89);
   });
 
   it('should be able to configure a userAgent with a wildcard', async () => {
     const hero = new Hero({
-      userAgent: '~ chrome = 88.x',
+      userAgent: `~ chrome = ${chromeVersion}.x`,
     });
     Helpers.needsClosing.push(hero);
 
@@ -238,7 +241,7 @@ describe('user hero and platform', () => {
     const chromeMatch = heroMeta.userAgentString.match(/Chrome\/(\d+)/);
     expect(chromeMatch).toBeTruthy();
     const version = Number(chromeMatch[1]);
-    expect(version).toBe(88);
+    expect(version).toBe(89);
   });
 
   it('should add user hero and platform to window & frames', async () => {

--- a/interfaces/IDevtoolsSession.ts
+++ b/interfaces/IDevtoolsSession.ts
@@ -2,6 +2,7 @@ import { ProtocolMapping } from 'devtools-protocol/types/protocol-mapping';
 import Protocol from 'devtools-protocol';
 import ITypedEventEmitter from '@ulixee/commons/interfaces/ITypedEventEmitter';
 import { FilterFlags, FilterOutFlags } from './AllowedNames';
+import RemoteObject = Protocol.Runtime.RemoteObject;
 
 export declare type DevtoolsEvents = {
   [Key in keyof ProtocolMapping.Events]: ProtocolMapping.Events[Key][0];
@@ -16,6 +17,8 @@ type RequiredParamsCommands = keyof FilterOutFlags<DevtoolsCommandParams, void |
 export default interface IDevtoolsSession
   extends Omit<ITypedEventEmitter<DevtoolsEvents>, 'waitOn'> {
   id: string;
+  disposeRemoteObject(object: RemoteObject): void;
+
   send<T extends RequiredParamsCommands>(
     method: T,
     params: DevtoolsCommandParams[T],

--- a/interfaces/IPuppetBrowser.ts
+++ b/interfaces/IPuppetBrowser.ts
@@ -14,6 +14,7 @@ export default interface IPuppetBrowser {
     plugins: ICorePlugins,
     logger: IBoundLog,
     proxy?: IProxyConnectionOptions,
+    isIncognito?: boolean,
   ): Promise<IPuppetContext>;
   close(): Promise<void>;
 }

--- a/interfaces/IPuppetContext.ts
+++ b/interfaces/IPuppetContext.ts
@@ -33,6 +33,7 @@ export interface IPuppetPageOptions {
 export interface IPuppetContextEvents {
   page: { page: IPuppetPage };
   worker: { worker: IPuppetWorker };
+  close: void;
   'devtools-message': {
     direction: 'send' | 'receive';
     timestamp: Date;

--- a/plugins/default-browser-emulator/index.ts
+++ b/plugins/default-browser-emulator/index.ts
@@ -41,8 +41,8 @@ import configureDeviceProfile from './lib/helpers/configureDeviceProfile';
 import configureHttp2Session from './lib/helpers/configureHttp2Session';
 
 const dataLoader = new DataLoader(__dirname);
-export const latestBrowserEngineId = 'chrome-88-0';
-export const latestChromeBrowserVersion = { major: '88', minor: '0' };
+export const latestBrowserEngineId = 'chrome-89-0';
+export const latestChromeBrowserVersion = { major: '89', minor: '0' };
 
 @BrowserEmulatorClassDecorator
 export default class DefaultBrowserEmulator extends BrowserEmulator {

--- a/plugins/default-browser-emulator/lib/helpers/setScreensize.ts
+++ b/plugins/default-browser-emulator/lib/helpers/setScreensize.ts
@@ -17,15 +17,13 @@ export default async function setScreensize(
   if (emulator.browserEngine.isHeaded && viewport.screenWidth) {
     promises.push(
       page.devtoolsSession.send('Browser.getWindowForTarget').then(({ windowId, bounds }) => {
-        if (bounds.width === viewport.width && bounds.height === viewport.height) {
+        if (bounds.width === viewport.screenWidth && bounds.height === viewport.screenHeight) {
           return null;
         }
 
         return devtools.send('Browser.setWindowBounds', {
           windowId,
           bounds: {
-            left: viewport.positionX,
-            top: viewport.positionY,
             width: viewport.screenWidth,
             height: viewport.screenHeight,
             windowState: 'normal',
@@ -35,8 +33,7 @@ export default async function setScreensize(
     );
   }
 
-  const ignoreViewport =
-    sessionMeta.options?.showBrowserInteractions === true && viewport.isDefault;
+  const ignoreViewport = sessionMeta.options?.showBrowserInteractions === true;
   if (!ignoreViewport) {
     promises.push(
       devtools.send('Emulation.setDeviceMetricsOverride', {

--- a/plugins/default-browser-emulator/package.json
+++ b/plugins/default-browser-emulator/package.json
@@ -4,7 +4,7 @@
   "description": "Browser emulator generated from DoubleAgent data",
   "main": "index.js",
   "dependencies": {
-    "@ulixee/chrome-88-0": "^4324.182.4",
+    "@ulixee/chrome-89-0": "^4389.128.4",
     "@ulixee/commons": "1.5.5",
     "@ulixee/hero-interfaces": "1.5.4",
     "@ulixee/hero-plugin-utils": "1.5.4",

--- a/puppet-chrome/lib/Frame.ts
+++ b/puppet-chrome/lib/Frame.ts
@@ -342,12 +342,12 @@ export default class Frame extends TypedEventEmitter<IPuppetFrameEvents> impleme
 
   public removeContextId(executionContextId: number): void {
     if (this.defaultContextId === executionContextId) this.defaultContextId = null;
-    if (this.isolatedContextId === executionContextId) this.defaultContextId = null;
+    if (this.isolatedContextId === executionContextId) this.isolatedContextId = null;
   }
 
   public clearContextIds(): void {
     this.defaultContextId = null;
-    this.defaultContextId = null;
+    this.isolatedContextId = null;
   }
 
   public addContextId(executionContextId: number, isDefault: boolean): void {

--- a/puppet/index.ts
+++ b/puppet/index.ts
@@ -18,7 +18,7 @@ const { log } = Log(module);
 let puppBrowserCounter = 1;
 export default class Puppet extends TypedEventEmitter<{ close: void }> {
   public get browserId(): string {
-    return this.browser.id;
+    return this.browser?.id;
   }
 
   public readonly id: number;
@@ -79,12 +79,13 @@ export default class Puppet extends TypedEventEmitter<{ close: void }> {
     plugins: ICorePlugins,
     logger: IBoundLog,
     proxy?: IProxyConnectionOptions,
+    isIncognito = true,
   ): Promise<IPuppetContext> {
     if (!this.isStarted || !this.browser) {
       throw new Error('This Puppet instance has not had start() called on it');
     }
     if (this.isShuttingDown) throw new Error('Shutting down');
-    return this.browser.newContext(plugins, logger, proxy);
+    return this.browser.newContext(plugins, logger, proxy, isIncognito);
   }
 
   public async close() {

--- a/puppet/test/Page.test.ts
+++ b/puppet/test/Page.test.ts
@@ -22,7 +22,7 @@ describe('Pages', () => {
 
   beforeAll(async () => {
     Core.use(CustomBrowserEmulator);
-    const  { browserEngine } = CustomBrowserEmulator.selectBrowserMeta();
+    const { browserEngine } = CustomBrowserEmulator.selectBrowserMeta();
     server = await TestServer.create(0);
     puppet = new Puppet(browserEngine);
     await puppet.start();
@@ -78,14 +78,14 @@ describe('Pages', () => {
       await expect(message.frameId).toBe(page.mainFrame.id);
     });
 
-    it('should set the page close state', async () => {
+    it('page.close should set the page close state', async () => {
       const newPage = await context.newPage();
       expect(newPage.isClosed).toBe(false);
       await newPage.close();
       expect(newPage.isClosed).toBe(true);
     });
 
-    it('should be callable twice', async () => {
+    it('page.close should be callable twice', async () => {
       const newPage = await context.newPage();
       await Promise.all([newPage.close(), newPage.close()]);
       await expect(newPage.close()).resolves.not.toBeTruthy();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2145,10 +2145,10 @@
     "@typescript-eslint/types" "4.28.3"
     eslint-visitor-keys "^2.0.0"
 
-"@ulixee/chrome-88-0@^4324.182.4":
-  version "4324.182.4"
-  resolved "https://registry.yarnpkg.com/@ulixee/chrome-88-0/-/chrome-88-0-4324.182.4.tgz#b5de2e5e8569a380b6bff99074ef8d66c6bbb686"
-  integrity sha512-HZBSbZEVjWyjnkj/UYbnYd8dvHiXroeGPNGG3anOLHIW8dIDVnPtdwJXD/7Kcm6hUXVmZY2q3w1y5i8L94V9uQ==
+"@ulixee/chrome-89-0@^4389.128.4":
+  version "4389.128.4"
+  resolved "https://registry.yarnpkg.com/@ulixee/chrome-89-0/-/chrome-89-0-4389.128.4.tgz#a71f9739078c90d93e97bb26a2eac145ce397a45"
+  integrity sha512-BmoLbzC2ACmep5pAXnpK2HvvWbjeMxsum/9PDsyzdVlHzJ3HbdTVZuaqPrJ5h12ZYZbEK9PYlamy9twaaulDfA==
   dependencies:
     "@ulixee/chrome-app" "^1.0.2"
 


### PR DESCRIPTION
This PR adds an ability to use the default (non incognito) context in hero. This is primarily needed to run ChromeAlive's extension with an ability to group tabs.

Other fixes include:
- Upgrade default browser to chrome 89 - this is needed to enable styling tabGroups in extensions
- Fix closing issues from client when hero instance closed from server
- Fix node highlighting in page
- Fix interact issue where navigating to a known "id" could incorrectly think it was a coordinate