### PR TITLE
Mitm - disable including stack traces in network requests when headed, allow client specifying dns over tls provider

### DIFF
--- a/core/lib/Session.ts
+++ b/core/lib/Session.ts
@@ -174,6 +174,7 @@ export default class Session
       sessionOptions: providedOptions,
     });
     this.mitmRequestSession = new RequestSession(this.id, this.plugins, this.upstreamProxyUrl);
+    this.mitmRequestSession.respondWithHttpErrorStacks = options.showBrowserInteractions === true;
     this.commandRecorder = new CommandRecorder(this, this, null, null, [
       this.configure,
       this.detachTab,

--- a/docs/main/BasicInterfaces/Hero.md
+++ b/docs/main/BasicInterfaces/Hero.md
@@ -78,6 +78,9 @@ const Hero = require('@ulixee/hero');
   - userAgent `strong`. This sets your browser's user agent string. Prefixing this string with a tilde (~) allows for dynamic options.
   - browserEmulatorId `string` defaults to `default-browser-emulator`. Chooses the BrowserEmulator plugin which emulates the properties that help Hero look like a normal browser.
   - humanEmulatorId `string` defaults to `default-human-emulator`. Chooses the HumanEmulator plugin which drives the mouse/keyboard movements.
+  - dnsOverTlsProvider `object`. Configure the host and port to use for DNS over TLS. This feature replicates the Chrome feature that is used if the host DNS provider supports DNS over TLS or DNS over HTTPS. A `null` value will disable this feature.
+    - host `string`. The DNS provider host address. Google=8.8.8.8, Cloudflare=1.1.1.1, Quad9=9.9.9.9.
+    - servername `string`. The DNS provider tls servername. Google=dns.google, Cloudflare=cloudflare-dns.com, Quad9=dns.quad9.net.
   - geolocation `IGeolocation`. Overrides the geolocation of the user. Will automatically grant permissions to all origins for geolocation.
     - latitude `number`. Latitude between -90 and 90.
     - longitude `number`. Longitude between -180 and 180.

--- a/interfaces/ICorePlugin.ts
+++ b/interfaces/ICorePlugin.ts
@@ -158,6 +158,7 @@ export interface IBrowserEmulatorConfig {
   geolocation?: IGeolocation;
   timezoneId?: string;
   locale?: string;
+  dnsOverTlsProvider?: IDnsSettings['dnsOverTlsConnection'];
 }
 
 // decorator for browser emulator classes. hacky way to check the class implements statics we need

--- a/interfaces/ISessionCreateOptions.ts
+++ b/interfaces/ISessionCreateOptions.ts
@@ -26,7 +26,7 @@ export default interface ISessionCreateOptions extends ISessionOptions {
   geolocation?: IGeolocation;
   dependencyMap?: { [clientPluginId: string]: string[] };
   corePluginPaths?: string[];
-
+  dnsOverTlsProvider?: { host: string; port: number };
   showBrowser?: boolean;
   showBrowserInteractions?: boolean;
   allowManualBrowserInteraction?: boolean;

--- a/mitm/handlers/HttpRequestHandler.ts
+++ b/mitm/handlers/HttpRequestHandler.ts
@@ -154,7 +154,8 @@ export default class HttpRequestHandler extends BaseHttpHandler {
     try {
       if (!proxyToClientResponse.headersSent) {
         proxyToClientResponse.writeHead(status);
-        proxyToClientResponse.end(error.stack);
+        const errorText = this.context.requestSession.respondWithHttpErrorStacks ? error.stack : '';
+        proxyToClientResponse.end(errorText);
       } else if (!proxyToClientResponse.finished) {
         proxyToClientResponse.end();
       }

--- a/mitm/handlers/RequestSession.ts
+++ b/mitm/handlers/RequestSession.ts
@@ -47,6 +47,7 @@ export default class RequestSession extends TypedEventEmitter<IRequestSessionEve
     responseTime: Date;
   }[] = [];
 
+  public respondWithHttpErrorStacks = true;
   public readonly browserRequestMatcher: BrowserRequestMatcher;
 
   // use this to bypass the mitm and just return a dummy response (ie for UserProfile setup)

--- a/plugins/default-browser-emulator/index.ts
+++ b/plugins/default-browser-emulator/index.ts
@@ -52,6 +52,7 @@ export default class DefaultBrowserEmulator extends BrowserEmulator {
   public locale: string;
   public viewport: IViewport;
   public geolocation: IGeolocation;
+  public dnsOverTlsProvider: IDnsSettings['dnsOverTlsConnection'];
 
   protected readonly data: IBrowserData;
   private readonly domOverridesBuilder: DomOverridesBuilder;
@@ -82,10 +83,15 @@ export default class DefaultBrowserEmulator extends BrowserEmulator {
     this.viewport = config.viewport;
     this.timezoneId = config.timezoneId;
     this.geolocation = config.geolocation;
+    this.dnsOverTlsProvider = config.dnsOverTlsProvider;
   }
 
   public onDnsConfiguration(settings: IDnsSettings): void {
     configureSessionDns(this, settings);
+
+    if (this.dnsOverTlsProvider !== undefined) {
+      settings.dnsOverTlsConnection = this.dnsOverTlsProvider;
+    }
   }
 
   public onTcpConfiguration(settings: ITcpSettings): void {


### PR DESCRIPTION
This PR was made because requests that fail internally are showing stack traces in the headed UI, which is not desirable.

This PR also adds dns over tls configuration from client