### PR TITLE
fix: various timeline/pagestate bugs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+.eslintrc.js
+*.config.js
+tsconfig*.json

--- a/client/connections/ConnectionToCore.ts
+++ b/client/connections/ConnectionToCore.ts
@@ -195,7 +195,7 @@ export default abstract class ConnectionToCore extends TypedEventEmitter<{
     return this.coreSessions.get(sessionId);
   }
 
-  public closeSession(coreSession: CoreSession): void {
+  public untrackSession(coreSession: CoreSession): void {
     this.coreSessions.untrack(coreSession.sessionId);
   }
 

--- a/client/lib/PageState.ts
+++ b/client/lib/PageState.ts
@@ -6,7 +6,7 @@ import ISessionMeta from '@ulixee/hero-interfaces/ISessionMeta';
 import IPageStateResult from '@ulixee/hero-interfaces/IPageStateResult';
 import { readFileAsJson } from '@ulixee/commons/lib/fileUtils';
 import IPageStateAssertionBatch from '@ulixee/hero-interfaces/IPageStateAssertionBatch';
-import { IRawCommand } from '@ulixee/hero-interfaces/IPageStateListenArgs';
+import IPageStateListenArgs, { IRawCommand } from '@ulixee/hero-interfaces/IPageStateListenArgs';
 import CoreTab from './CoreTab';
 import IPageStateDefinitions, {
   IPageStateDefinitionFn,
@@ -14,6 +14,7 @@ import IPageStateDefinitions, {
 } from '../interfaces/IPageStateDefinitions';
 import Tab from './Tab';
 import DisconnectedFromCoreError from '../connections/DisconnectedFromCoreError';
+import { CanceledPromiseError } from '@ulixee/commons/interfaces/IPendingWaitEvent';
 
 let counter = 0;
 
@@ -51,12 +52,15 @@ export default class PageState<T extends IPageStateDefinitions, K = keyof T> {
     await this.collectAssertionCommands();
 
     const timer = new Timer(timeoutMs);
-    const states = Object.keys(this.#states);
-    await this.#coreTab.addEventListener(this.#jsPath, 'page-state', this.onStateChanged, {
+    const pageStateOptions: IPageStateListenArgs = {
       commands: this.#rawCommandsById,
       callsite: this.#callsite,
-      states,
-    });
+      states: Object.keys(this.#states),
+    };
+
+    await this.#coreTab
+      .addEventListener(this.#jsPath, 'page-state', this.onStateChanged, pageStateOptions)
+      .catch(this.rewriteNoStateError);
 
     let finalState: K;
     let waitError: Error;
@@ -77,6 +81,15 @@ export default class PageState<T extends IPageStateDefinitions, K = keyof T> {
         error: waitError,
       });
     }
+  }
+
+  private rewriteNoStateError(error: Error): void {
+    const states = Object.keys(this.#states);
+    if (error instanceof CanceledPromiseError && !states.length) {
+      error.name = 'ConfigurationRequired';
+      error.stack = `${error.name}: ${error.message}\n${error.stack.split(/\r?\n/).pop()}`;
+    }
+    throw error;
   }
 
   private async onStateChanged(stateResult: IPageStateResult): Promise<void> {
@@ -255,7 +268,7 @@ export default class PageState<T extends IPageStateDefinitions, K = keyof T> {
   ): Promise<void> {
     let assertionBatch = exportedStateOrPath as IPageStateAssertionBatch;
     if (typeof exportedStateOrPath === 'string') {
-      // if @, read from core
+      // @ is a shortcut meaning, "read from Core::CacheLocation"
       if (exportedStateOrPath.startsWith('@')) {
         assertionBatch = {
           id: exportedStateOrPath,
@@ -264,8 +277,8 @@ export default class PageState<T extends IPageStateDefinitions, K = keyof T> {
         };
       } else {
         assertionBatch = await readFileAsJson(exportedStateOrPath);
-        this.#batchAssertionPathToId[exportedStateOrPath] = assertionBatch.id;
       }
+      this.#batchAssertionPathToId[exportedStateOrPath] = assertionBatch.id;
     }
 
     this.#idCounter += 1;

--- a/client/lib/PageState.ts
+++ b/client/lib/PageState.ts
@@ -238,7 +238,7 @@ export default class PageState<T extends IPageStateDefinitions, K = keyof T> {
           }
         },
         loadFrom(exportedStateOrPath) {
-          const promise = loadAssertionBatch(exportedStateOrPath);
+          const promise = loadAssertionBatch(key, exportedStateOrPath);
           promises.push(promise);
         },
       });
@@ -264,6 +264,7 @@ export default class PageState<T extends IPageStateDefinitions, K = keyof T> {
   }
 
   private async loadAssertionBatch(
+    state: string,
     exportedStateOrPath: IPageStateAssertionBatch | string,
   ): Promise<void> {
     let assertionBatch = exportedStateOrPath as IPageStateAssertionBatch;
@@ -291,6 +292,7 @@ export default class PageState<T extends IPageStateDefinitions, K = keyof T> {
         this.#jsPath,
         assertionBatch.assertions,
         assertionBatch.minValidAssertions,
+        state,
       ],
     ];
     // NOTE: subtly different serialization - serialized command and local run just stores the id

--- a/client/lib/ScriptInstance.ts
+++ b/client/lib/ScriptInstance.ts
@@ -10,6 +10,7 @@ export default class ScriptInstance {
   public get meta(): IScriptInstanceMeta {
     return {
       id: this.id,
+      workingDirectory: process.cwd(),
       entrypoint: this.entrypoint,
       startDate: this.startDate,
     };

--- a/client/lib/ScriptInstance.ts
+++ b/client/lib/ScriptInstance.ts
@@ -1,8 +1,8 @@
-import { v1 as uuidv1 } from 'uuid';
+import { nanoid } from 'nanoid';
 import IScriptInstanceMeta from '@ulixee/hero-interfaces/IScriptInstanceMeta';
 
 export default class ScriptInstance {
-  public readonly id: string = uuidv1();
+  public readonly id: string = nanoid();
   public readonly entrypoint = require.main?.filename ?? process.argv[1];
   public readonly startDate = Date.now();
   private sessionNameCountByName: { [name: string]: number } = {};

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,7 @@
     "@ulixee/hero-interfaces": "1.5.4",
     "@ulixee/hero-plugin-utils": "1.5.4",
     "awaited-dom": "1.3.0",
-    "uuid": "^8.3.2",
+    "nanoid": "^3.1.30",
     "ws": "^7.4.4"
   },
   "devDependencies": {

--- a/core/connections/ConnectionToClient.ts
+++ b/core/connections/ConnectionToClient.ts
@@ -148,9 +148,9 @@ export default class ConnectionToClient
     if (this.isClosing) throw new Error('Connection closed');
     clearTimeout(this.autoShutdownTimer);
 
-    const { session, tab, isSessionResume } = await Session.create(options);
-    if (!isSessionResume) {
-      const sessionId = session.id;
+    const { session, tab } = await Session.create(options);
+    const sessionId = session.id;
+    if (!this.sessionIdToRemoteEvents.has(sessionId)) {
       this.sessionIdToRemoteEvents.set(
         sessionId,
         new RemoteEvents(this.emit.bind(this, 'message')),

--- a/core/lib/FrameNavigations.ts
+++ b/core/lib/FrameNavigations.ts
@@ -15,7 +15,7 @@ export interface IFrameNavigationEvents {
   'status-change': {
     id: number;
     url: string;
-    statusChanges: { [status: string]: Date };
+    statusChanges: Record<NavigationStatus, number>;
     newStatus: NavigationStatus;
   };
 }

--- a/core/lib/PageStateListener.ts
+++ b/core/lib/PageStateListener.ts
@@ -30,6 +30,7 @@ export default class PageStateListener extends TypedEventEmitter<IPageStateEvent
   public readonly startTime: number;
   public readonly startingCommandId: number;
   public readonly commandStartTime: number;
+  public readonly isLoaded: Promise<void | Error>;
 
   public readonly rawBatchAssertionsById = new Map<string, IPageStateAssertionBatch>();
 
@@ -40,7 +41,6 @@ export default class PageStateListener extends TypedEventEmitter<IPageStateEvent
   private isStopping = false;
   private isCheckingState = false;
   private runAgain = false;
-  private readyPromise: Promise<void | Error>;
   private watchedFrameIds = new Set<number>();
 
   constructor(
@@ -68,7 +68,7 @@ export default class PageStateListener extends TypedEventEmitter<IPageStateEvent
     this.startTime = previousCommand ? previousCommand.runStartDate + 1 : Date.now();
 
     tab.once('close', this.stop);
-    this.readyPromise = this.bindFrameEvents().catch(err => err);
+    this.isLoaded = this.bindFrameEvents().catch(err => err);
     this.checkInterval = setInterval(this.checkState, 2e3).unref();
   }
 

--- a/core/lib/RemoteEventListener.ts
+++ b/core/lib/RemoteEventListener.ts
@@ -59,7 +59,7 @@ export default class RemoteEventListener implements ICommandableTarget {
     }
   }
 
-  public addEventListener(
+  public async addEventListener(
     jsPath: IJsPath | null,
     type: string,
     options?: any,
@@ -77,18 +77,19 @@ export default class RemoteEventListener implements ICommandableTarget {
 
     if (jsPath && 'addJsPathEventListener' in target) {
       const fn = target.addJsPathEventListener.bind(target);
-      fn(type as any, jsPath, options, listener.listenFn);
+      await fn(type as any, jsPath, options, listener.listenFn);
     } else if ('on' in target) {
       const fn = target.on.bind(target) as any;
       fn(type, listener.listenFn);
     }
 
-    return Promise.resolve({ listenerId });
+    return { listenerId };
   }
 
   public removeEventListener(id: string, options?: any): Promise<void> {
     const listener = this.listenersById.get(id);
     this.listenersById.delete(id);
+    if (!listener) return;
 
     const { type, listenFn, jsPath } = listener;
     const target = this.target;

--- a/core/lib/Session.ts
+++ b/core/lib/Session.ts
@@ -1,4 +1,4 @@
-import { v1 as uuidv1 } from 'uuid';
+import { nanoid } from 'nanoid';
 import Log, { ILogEntry, LogEvents, loggerSessionIdNames } from '@ulixee/commons/lib/Logger';
 import RequestSession, {
   IRequestSessionHttpErrorEvent,
@@ -480,13 +480,13 @@ export default class Session
         throw new Error('The pre-provided sessionId is already in use.');
       }
       // make sure this is a valid sessionid
-      if (/^[0-9a-zA-Z-]{1,48}/.test(sessionId) === false) {
+      if (/^[0-9a-zA-Z-_]{6,}/.test(sessionId) === false) {
         throw new Error(
-          'Unsupported sessionId format provided. Must be 5-48 characters including: a-z, 0-9 and dashes.',
+          'Unsupported sessionId format provided. Must be > 10 characters including: a-z, 0-9 and dashes.',
         );
       }
     }
-    return sessionId ?? uuidv1();
+    return sessionId ?? nanoid();
   }
 
   private onDevtoolsMessage(event: IPuppetContextEvents['devtools-message']): void {

--- a/core/lib/Tab.ts
+++ b/core/lib/Tab.ts
@@ -658,10 +658,15 @@ export default class Tab
     return await pageStateListener.runBatchAssert(batchId);
   }
 
-  public addPageStateListener(id: string, options: IPageStateListenArgs): PageStateListener {
+  public async addPageStateListener(
+    id: string,
+    options: IPageStateListenArgs,
+  ): Promise<PageStateListener> {
     const listener = new PageStateListener(id, options, this);
     this.pageStateListeners[id] = listener;
     listener.on('resolved', () => delete this.pageStateListeners[id]);
+
+    await listener.isLoaded;
 
     this.emit('wait-for-pagestate', { listener });
 
@@ -677,12 +682,12 @@ export default class Tab
     return listener;
   }
 
-  public addJsPathEventListener(
+  public async addJsPathEventListener(
     type: 'message' | 'page-state',
     jsPath: IJsPath,
     options: any,
     listenFn: (...args) => void,
-  ): void {
+  ): Promise<void> {
     if (type === 'message') {
       const [domain, resourceId] = jsPath;
       if (domain !== 'resources') {
@@ -694,7 +699,7 @@ export default class Tab
 
     if (type === 'page-state') {
       const id = JSON.stringify(jsPath);
-      const listener = this.addPageStateListener(id, options);
+      const listener = await this.addPageStateListener(id, options);
       listener.on('state', listenFn);
     }
   }

--- a/core/lib/UserProfile.ts
+++ b/core/lib/UserProfile.ts
@@ -40,11 +40,7 @@ export default class UserProfile {
           );
           originStorage.localStorage = liveData.localStorage;
           originStorage.sessionStorage = liveData.sessionStorage;
-          for (const dbWithData of liveData.indexedDB) {
-            if (!dbWithData) continue;
-            const idx = originStorage.indexedDB.findIndex(x => x.name === dbWithData.name);
-            originStorage.indexedDB[idx] = dbWithData;
-          }
+          originStorage.indexedDB = liveData.indexedDB;
         }
       }
     }

--- a/core/models/SessionsTable.ts
+++ b/core/models/SessionsTable.ts
@@ -11,6 +11,7 @@ export default class SessionsTable extends SqliteTable<ISessionsRecord> {
       ['scriptInstanceId', 'TEXT'],
       ['scriptEntrypoint', 'TEXT'],
       ['scriptStartDate', 'TEXT'],
+      ['workingDirectory', 'TEXT'],
     ]);
   }
 
@@ -25,6 +26,7 @@ export default class SessionsTable extends SqliteTable<ISessionsRecord> {
       scriptInstanceMeta?.id,
       scriptInstanceMeta?.entrypoint,
       new Date(scriptInstanceMeta?.startDate).toISOString(),
+      scriptInstanceMeta?.workingDirectory,
     ];
     this.insertNow(record);
   }
@@ -49,4 +51,5 @@ export interface ISessionsRecord {
   scriptInstanceId: string;
   scriptEntrypoint: string;
   scriptStartDate: string;
+  workingDirectory: string;
 }

--- a/core/models/StorageChangesTable.ts
+++ b/core/models/StorageChangesTable.ts
@@ -43,7 +43,7 @@ export default class StorageChangesTable extends SqliteTable<IStorageChangesEntr
       .prepare(
         `select * from ${this.tableName}
                 where tabId = ? and securityOrigin = :securityOrigin
-                    and type = :type and action = :type and key = :key
+                    and type = :type and action = :action and key = :key
                 limit 1`,
       )
       .get(tabId, filter);

--- a/core/package.json
+++ b/core/package.json
@@ -29,7 +29,7 @@
     "better-sqlite3": "^7.4.1",
     "moment": "^2.24.1",
     "tough-cookie": "^4.0.0",
-    "uuid": "^8.3.2",
+    "nanoid": "^3.1.30",
     "ws": "^7.4.4"
   },
   "devDependencies": {

--- a/core/test/apis.test.ts
+++ b/core/test/apis.test.ts
@@ -33,6 +33,7 @@ describe('basic Apis tests', () => {
       humanEmulatorId: 'basic',
       scriptInstanceMeta: {
         startDate: Date.now(),
+        workingDirectory: process.cwd(),
         entrypoint: 'testEntrypoint.js',
         id: '1234',
       },

--- a/core/test/navigation.test.ts
+++ b/core/test/navigation.test.ts
@@ -404,7 +404,7 @@ setTimeout(function() {
       },
     ]);
 
-    const spy = jest.spyOn<any, any>(FrameNavigationsObserver.prototype, 'resolvePendingStatus');
+    const spy = jest.spyOn<any, any>(FrameNavigationsObserver.prototype, 'resolvePendingTrigger');
 
     // clear data before this run
     const popupTab = await tab.waitForNewTab();

--- a/core/test/pageState.test.ts
+++ b/core/test/pageState.test.ts
@@ -32,7 +32,7 @@ test('can wait for page state events', async () => {
   await tab.goto(`${koaServer.baseUrl}/pageState1`);
   const callbackFn = jest.fn();
   const hasDiv = new Resolvable<void>();
-  const listener = tab.addPageStateListener('1', {
+  const listener = await tab.addPageStateListener('1', {
     callsite: 'callsite',
     states: ['states'],
     commands: {
@@ -73,8 +73,6 @@ test('can wait for page state events', async () => {
 
 test('can continue to get events as dom changes', async () => {
   const { tab } = await createSession();
-  await tab.recordScreen({ jpegQuality: 10, format: 'jpeg' });
-
   koaServer.get('/pageState2', ctx => {
     ctx.body = `
   <body>
@@ -94,7 +92,7 @@ test('can continue to get events as dom changes', async () => {
   await tab.goto(`${koaServer.baseUrl}/pageState2`);
   const callbackFn = jest.fn();
   const hasDiv = new Resolvable<void>();
-  const listener = tab.addPageStateListener('2', {
+  const listener = await tab.addPageStateListener('2', {
     callsite: 'callsite',
     states: ['states'],
     commands: {
@@ -118,8 +116,6 @@ test('can continue to get events as dom changes', async () => {
 
   await hasDiv.promise;
   listener.stop();
-  await tab.stopRecording();
-  expect(tab.session.db.screenshots.screenshotTimesByTabId.size).toBeGreaterThanOrEqual(1);
   expect(callbackFn.mock.calls.length).toBeGreaterThanOrEqual(2);
   const lastCall = callbackFn.mock.calls.slice(-1).shift()[0];
   expect(lastCall.url).toBe(`${koaServer.baseUrl}/pageState2`);

--- a/interfaces/IScriptInstanceMeta.ts
+++ b/interfaces/IScriptInstanceMeta.ts
@@ -2,4 +2,5 @@ export default interface IScriptInstanceMeta {
   id: string;
   entrypoint: string;
   startDate: number;
+  workingDirectory: string;
 }

--- a/mitm-socket/lib/BaseIpcHandler.ts
+++ b/mitm-socket/lib/BaseIpcHandler.ts
@@ -7,7 +7,8 @@ import Resolvable from '@ulixee/commons/lib/Resolvable';
 import { IBoundLog } from '@ulixee/commons/interfaces/ILog';
 import { CanceledPromiseError } from '@ulixee/commons/interfaces/IPendingWaitEvent';
 import { bindFunctions } from '@ulixee/commons/lib/utils';
-import { createId, createIpcSocketPath } from '@ulixee/commons/lib/IpcUtils';
+import { createIpcSocketPath } from '@ulixee/commons/lib/IpcUtils';
+import { nanoid } from 'nanoid';
 import * as Fs from 'fs';
 import * as Path from 'path';
 
@@ -201,7 +202,7 @@ export default abstract class BaseIpcHandler {
     options.mode = mode;
 
     if (options.ipcSocketPath === undefined) {
-      const id = createId();
+      const id = nanoid();
       options.ipcSocketPath = createIpcSocketPath(`ipc-${mode}-${id}`);
     }
     return options as IGoIpcOpts;

--- a/mitm-socket/package.json
+++ b/mitm-socket/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@ulixee/commons": "1.5.7",
     "@ulixee/hero-interfaces": "1.5.4",
-    "uuid": "^8.3.2"
+    "nanoid": "^3.1.30"
   },
   "devDependencies": {
     "@ulixee/hero-testing": "1.5.4",

--- a/plugins/default-human-emulator/index.ts
+++ b/plugins/default-human-emulator/index.ts
@@ -136,10 +136,11 @@ export default class DefaultHumanEmulator extends HumanEmulator {
 
     const { nodeId } = targetRect;
 
-    const targetPoint = getRandomRectPoint(targetRect, DefaultHumanEmulator.boxPaddingPercent);
+    let targetPoint = getRandomRectPoint(targetRect, DefaultHumanEmulator.boxPaddingPercent);
     const didMoveMouse = await this.moveMouseToPoint(targetPoint, targetRect.width, runFn, helper);
     if (didMoveMouse) {
       targetRect = await helper.lookupBoundingRect([nodeId], true, true);
+      targetPoint = getRandomRectPoint(targetRect, DefaultHumanEmulator.boxPaddingPercent)
     }
 
     if (targetRect.elementTag === 'option') {

--- a/puppet-chrome/lib/Page.ts
+++ b/puppet-chrome/lib/Page.ts
@@ -330,6 +330,7 @@ export class Page extends TypedEventEmitter<IPuppetPageEvents> implements IPuppe
     await this.devtoolsSession.send('Page.startScreencast', {
       format: options.format,
       quality: options.jpegQuality,
+      everyNthFrame: 1,
     });
   }
 

--- a/puppet/test/load.test.ts
+++ b/puppet/test/load.test.ts
@@ -67,7 +67,7 @@ describe('Load test', () => {
         await navigate;
         expect(page.mainFrame.url).toBe(`${server.crossProcessBaseUrl}/empty.html`);
       } finally {
-        await page.close();
+        await page?.close();
       }
     });
     await Promise.all(concurrent);

--- a/timetravel/injected-scripts/domReplayer.ts
+++ b/timetravel/injected-scripts/domReplayer.ts
@@ -39,6 +39,7 @@ class DomReplayer {
   }
 
   public loadPaintEvents(newPaintEvents: IFrontendDomChangeEvent[][]): void {
+    this.pendingDomChanges.length = 0;
     this.paintEvents = newPaintEvents;
     this.loadedIndex = -1;
     debugLog('Loaded PaintEvents', newPaintEvents);
@@ -163,7 +164,7 @@ class DomReplayer {
     if (document.readyState === 'complete') {
       DomReplayer.register();
     } else {
-      window.addEventListener('DOMContentLoaded', () => DomReplayer.register());
+      window.addEventListener('DOMContentLoaded', () => DomReplayer.register(), { once: true });
     }
   }
 }

--- a/timetravel/lib/CommandTimeline.ts
+++ b/timetravel/lib/CommandTimeline.ts
@@ -145,6 +145,27 @@ export default class CommandTimeline<T extends ICommandMeta = ICommandMeta> {
     return -1;
   }
 
+  public toJSON(): unknown {
+    return {
+      startTime: this.startTime,
+      endTime: this.endTime,
+      runtimeMs: this.runtimeMs,
+      commands: this.commands.map(x => {
+        return {
+          id: x.id,
+          run: x.run,
+          reusedCommandFromRun: x.reusedCommandFromRun,
+          name: x.name,
+          startTime: x.startTime,
+          endTime: x.endDate,
+          relativeStartMs: x.relativeStartMs,
+          commandGapMs: x.commandGapMs,
+          runtimeMs: x.runtimeMs,
+        }
+      })
+    }
+  }
+
   private getTimelineOffsetForRuntimeMillis(timelineOffsetMs: number): number {
     return roundFloor((100 * timelineOffsetMs) / this.runtimeMs);
   }

--- a/timetravel/lib/CommandTimeline.ts
+++ b/timetravel/lib/CommandTimeline.ts
@@ -78,18 +78,23 @@ export default class CommandTimeline<T extends ICommandMeta = ICommandMeta> {
           continue;
         }
       }
-
-      // don't set a negative runtime
-      command.runtimeMs = Math.max(endDate - command.startTime, 0);
-
       // only use a gap if the command and previous are from the same run
       const prev = this.commandsFromAllRuns[this.commandsFromAllRuns.length - 1];
       if (
         prev?.run === command.run &&
         prev?.reusedCommandFromRun === command.reusedCommandFromRun
       ) {
+        if (command.startTime < prev.endDate) command.startTime = prev.endDate;
+        // if this ended before previous ended, need to skip it (probably in parallel)
+        if (endDate < prev.endDate) {
+          continue;
+        }
         command.commandGapMs = Math.max(command.startTime - prev.endDate, 0);
       }
+
+      // don't set a negative runtime
+      command.runtimeMs = Math.max(endDate - command.startTime, 0);
+
       this.commandsFromAllRuns.push(command);
 
       if (command.run === this.run) {
@@ -134,13 +139,13 @@ export default class CommandTimeline<T extends ICommandMeta = ICommandMeta> {
         const msSinceCommandStart = timestamp - command.startTime;
         const adjustedTime = msSinceCommandStart + command.relativeStartMs;
 
-        return this.getTimelineOffset(adjustedTime);
+        return this.getTimelineOffsetForRuntimeMillis(adjustedTime);
       }
     }
     return -1;
   }
 
-  public getTimelineOffset(timelineOffsetMs: number): number {
+  private getTimelineOffsetForRuntimeMillis(timelineOffsetMs: number): number {
     return roundFloor((100 * timelineOffsetMs) / this.runtimeMs);
   }
 
@@ -187,5 +192,5 @@ export default class CommandTimeline<T extends ICommandMeta = ICommandMeta> {
 }
 
 function roundFloor(num: number): number {
-  return Math.floor(10 * num) / 10;
+  return Math.round(10 * num) / 10;
 }

--- a/timetravel/lib/MirrorNetwork.ts
+++ b/timetravel/lib/MirrorNetwork.ts
@@ -96,6 +96,7 @@ export default class MirrorNetwork {
     resources: (IResourceSummary | IResourcesRecord)[],
     loadResourceDetails: (id: number) => Promise<ISessionResourceDetails> | ISessionResourceDetails,
   ): void {
+    this.resourceLookup = {};
     for (let resource of resources) {
       if (!(resource as IResourceSummary).method) {
         resource = ResourcesTable.toResourceSummary(resource as IResourcesRecord);

--- a/timetravel/lib/PageStateAssertions.ts
+++ b/timetravel/lib/PageStateAssertions.ts
@@ -28,6 +28,10 @@ export default class PageStateAssertions {
     if (frameAssertions) return frameAssertions[query];
   }
 
+  public clearSessionAssertions(sessionId: string): void {
+    this.assertsBySessionId[sessionId] = {};
+  }
+
   public recordAssertion(
     sessionId: string,
     frameId: number,

--- a/timetravel/lib/PageStateAssertions.ts
+++ b/timetravel/lib/PageStateAssertions.ts
@@ -84,9 +84,11 @@ export default class PageStateAssertions {
       // remove anything in the shared state that's not in this run
       for (const [frameId, sharedAssertions] of Object.entries(state)) {
         for (const key of Object.keys(sharedAssertions)) {
-          if (!sessionAssertionsByFrameId[frameId]) continue;
           const sessionFrameAssertions = sessionAssertionsByFrameId[frameId];
-          if (!sessionFrameAssertions[key]) {
+          
+          if (!sessionFrameAssertions) {
+            delete state[frameId];
+          } else if (!sessionFrameAssertions[key]) {
             delete state[frameId][key];
           }
         }

--- a/timetravel/lib/PageStateCodeBlock.ts
+++ b/timetravel/lib/PageStateCodeBlock.ts
@@ -14,7 +14,7 @@ export default class PageStateCodeBlock {
   }
 
   public static async generateCodeBlock(generator: PageStateGenerator): Promise<string> {
-    let code = `tab.waitForPageState({`;
+    let code = `{`;
 
     const id = generator.id;
     await Fs.promises.mkdir(`${defaultCacheDir}/pagestate/${id}`, { recursive: true });
@@ -22,12 +22,14 @@ export default class PageStateCodeBlock {
       const exported = generator.export(state);
       const savePath = Path.normalize(`${defaultCacheDir}/pagestate/${id}/${exported.id}.json`);
       await Fs.promises.writeFile(savePath, JSON.stringify(exported));
-      code += `\n  ${JSON.stringify(state)}: ({ loadFrom }) => loadFrom(${JSON.stringify(
-        `@/pagestate/${id}/${state}.json`,
+      const stateKey = JSON.stringify(state);
+
+      code += `\n  ${stateKey}: ({ loadFrom }) => loadFrom(${JSON.stringify(
+        `@/pagestate/${id}/${exported.id}.json`,
       )}),`;
     }
 
-    code += `\n});`;
+    code += `\n}`;
 
     return code;
   }

--- a/timetravel/lib/PageStateGenerator.ts
+++ b/timetravel/lib/PageStateGenerator.ts
@@ -175,6 +175,7 @@ export default class PageStateGenerator {
 
       if (!needsResultsVerification) continue;
 
+      this.sessionAssertions.clearSessionAssertions(sessionId);
       const [start, end] = loadingRange;
       const timeoutMs = end - Date.now();
 
@@ -470,15 +471,16 @@ export default class PageStateGenerator {
     const { tabId, db, loadingRange, sessionId } = session;
     const [, endTime] = loadingRange;
 
+    // going in descending order
     for (const nav of db.frameNavigations.getMostRecentTabNavigations(
       tabId,
       session.mainFrameIds,
     )) {
       if (nav.httpRespondedTime && !nav.httpRedirectedTime) {
         lastNavigation = nav;
-        if (nav.httpRespondedTime < endTime) break;
+        // if this was requested before the end time, use it
+        if (nav.httpRequestedTime && nav.httpRequestedTime < endTime) break;
       }
-      if (nav.httpRequestedTime && nav.httpRequestedTime < endTime) break;
     }
 
     if (!lastNavigation) {

--- a/timetravel/lib/PageStateGenerator.ts
+++ b/timetravel/lib/PageStateGenerator.ts
@@ -93,16 +93,16 @@ export default class PageStateGenerator {
     }
   }
 
-  public import(savedState: IPageStateGeneratorAssertionBatch): void {
-    if (!this.statesByName.has(savedState.state)) {
-      this.statesByName.set(savedState.state, {
+  public import(stateName: string, savedState: IPageStateGeneratorAssertionBatch): void {
+    if (!this.statesByName.has(stateName)) {
+      this.statesByName.set(stateName, {
         sessionIds: new Set<string>(),
         assertsByFrameId: {},
         id: savedState.id,
       });
     }
-    this.addState(savedState.state, ...savedState.sessions.map(x => x.sessionId));
-    const state = this.statesByName.get(savedState.state);
+    this.addState(stateName, ...savedState.sessions.map(x => x.sessionId));
+    const state = this.statesByName.get(stateName);
     state.startingAssertsByFrameId = {};
     const startingAssertions = state.startingAssertsByFrameId;
     for (const [frameId, type, args, comparison, result] of savedState.assertions) {
@@ -135,7 +135,6 @@ export default class PageStateGenerator {
       id: this.statesByName.get(stateName).id,
       sessions: [],
       assertions: [],
-      state: stateName,
     };
     const state = this.statesByName.get(stateName);
     for (const sessionId of state.sessionIds) {
@@ -522,7 +521,6 @@ export default class PageStateGenerator {
 }
 
 export interface IPageStateGeneratorAssertionBatch extends IPageStateAssertionBatch {
-  state: string;
   sessions: {
     sessionId: string;
     dbLocation: string; // could be on another machine

--- a/timetravel/player/TabPlaybackController.ts
+++ b/timetravel/player/TabPlaybackController.ts
@@ -160,11 +160,6 @@ export default class TabPlaybackController {
     newTickOrIdx: number | ITick,
     specificTimelineOffset?: number,
   ): Promise<void> {
-    console.log('loading new tick', {
-      newTickOrIdx,
-      specificTimelineOffset,
-      willProcess: newTickOrIdx === this.currentTickIndex || newTickOrIdx === this.currentTick,
-    });
     if (newTickOrIdx === this.currentTickIndex || newTickOrIdx === this.currentTick) {
       return;
     }
@@ -194,7 +189,6 @@ export default class TabPlaybackController {
         startIndex = this.paintEventsLoadedIdx + 1;
       }
 
-      console.log('loading ticks', [startIndex, newPaintIndex]);
       this.paintEventsLoadedIdx = newPaintIndex;
       await mirrorPage.load([startIndex, newPaintIndex]);
     }

--- a/timetravel/player/TimelineBuilder.ts
+++ b/timetravel/player/TimelineBuilder.ts
@@ -47,9 +47,10 @@ export default class TimelineBuilder extends TypedEventEmitter<{
 
   public setTimeRange(startTime: number, endTime?: number): void {
     this.timelineRange = [startTime, endTime];
-    this.commandTimeline = this.liveHeroSession
-      ? CommandTimeline.fromSession(this.liveHeroSession, this.timelineRange)
-      : CommandTimeline.fromDb(this.db, this.timelineRange);
+    // need to refresh from db. RefreshMetadata will update live
+    if (!this.liveHeroSession) {
+      this.commandTimeline = CommandTimeline.fromDb(this.db, this.timelineRange);
+    }
     this.refreshMetadata();
   }
 

--- a/timetravel/player/TimelineRecorder.ts
+++ b/timetravel/player/TimelineRecorder.ts
@@ -1,0 +1,125 @@
+import { LoadStatus } from '@ulixee/hero-interfaces/Location';
+import { IFrameNavigationEvents } from '@ulixee/hero-core/lib/FrameNavigations';
+import { ContentPaint } from '@ulixee/hero-interfaces/INavigation';
+import { Session, Tab } from '@ulixee/hero-core';
+import { bindFunctions } from '@ulixee/commons/lib/utils';
+import { TypedEventEmitter } from '@ulixee/commons/lib/eventUtils';
+
+export default class TimelineRecorder extends TypedEventEmitter<{
+  updated: void;
+}> {
+  public recordScreenUntilTime = 0;
+  public recordScreenUntilLoad = false;
+  private isPaused = false;
+
+  constructor(readonly heroSession: Session) {
+    super();
+    bindFunctions(this);
+
+    heroSession.on('tab-created', this.onTabCreated);
+    heroSession.on('kept-alive', this.onHeroSessionPaused);
+    heroSession.on('resumed', this.onHeroSessionResumed);
+    heroSession.on('will-close', this.onHeroSessionWillClose);
+
+    heroSession.db.screenshots.subscribe(() => this.emit('updated'));
+    heroSession.once('closed', () => {
+      heroSession.off('tab-created', this.onTabCreated);
+      heroSession.db.screenshots.unsubscribe();
+    });
+  }
+
+  public stop(): void {
+    if (!this.heroSession) return;
+    this.heroSession.off('tab-created', this.onTabCreated);
+    this.heroSession.off('kept-alive', this.onHeroSessionPaused);
+    this.heroSession.off('resumed', this.onHeroSessionResumed);
+    this.heroSession.on('will-close', this.onHeroSessionWillClose);
+    this.stopRecording();
+  }
+
+  public getScreenshot(tabId: number, timestamp: number): string {
+    const image = this.heroSession.db.screenshots.getImage(tabId, timestamp);
+    if (image) return image.toString('base64');
+  }
+
+  private onHeroSessionResumed(): void {
+    this.isPaused = false;
+    if (!this.heroSession) return;
+
+    for (const tab of this.heroSession.tabsById.values()) {
+      this.recordTab(tab);
+    }
+  }
+
+  private onHeroSessionWillClose(event: { waitForPromise?: Promise<any> }): void {
+    if (!this.recordScreenUntilTime && !this.recordScreenUntilLoad) return;
+    let loadPromise: Promise<any>;
+    if (this.recordScreenUntilLoad && this.heroSession) {
+      loadPromise = Promise.all(
+        [...this.heroSession.tabsById.values()].map(x => {
+          return x.navigationsObserver.waitForLoad(LoadStatus.AllContentLoaded);
+        }),
+      );
+    }
+
+    const delay = this.recordScreenUntilTime - Date.now();
+    let delayPromise: Promise<void>;
+    if (delay > 0) {
+      delayPromise = new Promise<void>(resolve => setTimeout(resolve, delay));
+    }
+    if (loadPromise || delayPromise) {
+      event.waitForPromise = Promise.race([
+        // max wait time
+        new Promise<void>(resolve => setTimeout(resolve, 60e3)),
+        Promise.all([loadPromise, delayPromise]),
+      ]).catch(() => null);
+    }
+  }
+
+  private onHeroSessionPaused(): void {
+    this.isPaused = true;
+    if (!this.heroSession) return;
+    this.stopRecording();
+  }
+
+  private stopRecording(): void {
+    for (const tab of this.heroSession.tabsById.values()) {
+      tab
+        .stopRecording()
+        .then(() => this.emit('updated'))
+        .catch(console.error);
+    }
+  }
+
+  private onTabCreated(event: { tab: Tab }): void {
+    const tab = event.tab;
+    tab.navigations.on('status-change', this.onStatusChange);
+    tab.once('close', () => {
+      tab.navigations.off('status-change', this.onStatusChange);
+    });
+    if (this.isPaused) return;
+
+    this.recordTab(tab);
+  }
+
+  private recordTab(tab: Tab): void {
+    tab
+      .recordScreen({
+        includeWhiteScreens: true,
+        includeDuplicates: true,
+        jpegQuality: 1,
+        format: 'jpeg',
+      })
+      .catch(console.error);
+  }
+
+  private onStatusChange(status: IFrameNavigationEvents['status-change']): void {
+    if (
+      [LoadStatus.DomContentLoaded, LoadStatus.AllContentLoaded, ContentPaint].includes(
+        status.newStatus,
+      )
+    ) {
+      this.emit('updated');
+    }
+  }
+}

--- a/timetravel/player/TimetravelPlayer.ts
+++ b/timetravel/player/TimetravelPlayer.ts
@@ -159,6 +159,7 @@ export default class TimetravelPlayer extends TypedEventEmitter<{
   public async refreshTicks(
     timelineOffsetRange: [startTime: number, endTime?: number],
   ): Promise<void> {
+    if (this.timelineRange && this.timelineRange.toString() === timelineOffsetRange.toString()) return;
     this.timelineRange = [...timelineOffsetRange];
     await this.load();
   }

--- a/timetravel/player/TimetravelPlayer.ts
+++ b/timetravel/player/TimetravelPlayer.ts
@@ -148,7 +148,7 @@ export default class TimetravelPlayer extends TypedEventEmitter<{
     for (const tab of this.tabsById.values()) {
       await tab.close();
     }
-    this.activeTab = null;
+    if (this.activeTab) await this.activeTab.mirrorPage.close();
     this.tabsById.clear();
   }
 

--- a/timetravel/test/PageStateGenerator.test.ts
+++ b/timetravel/test/PageStateGenerator.test.ts
@@ -483,8 +483,8 @@ describe('pageStateGenerator', () => {
     expect(state2.sessions).toHaveLength(2);
 
     const psg2 = new PageStateGenerator('id');
-    psg2.import(state1);
-    psg2.import(state2);
+    psg2.import('1', state1);
+    psg2.import('2', state2);
 
     changeTitle = true;
     // add sessions to the second round

--- a/timetravel/test/commandTimeline.test.ts
+++ b/timetravel/test/commandTimeline.test.ts
@@ -53,10 +53,11 @@ test('should be able to calculate offsets', async () => {
   const navigations = [{ id: 1, url: '1', statusChanges: new Map() } as any] as INavigation[];
 
   const commandTimeline = new CommandTimeline(commands, 1, navigations);
-  expect(commandTimeline.getTimelineOffset(60)).toBe(50.0);
+  // @ts-ignore
+  expect(commandTimeline.getTimelineOffsetForRuntimeMillis(60)).toBe(50.0);
   // if timestamp is in the gap, we shouldn't include it
   expect(commandTimeline.getTimelineOffsetForTimestamp(1000)).toBe(-1);
-  expect(commandTimeline.getTimelineOffsetForTimestamp(1500)).toBe(91.6);
+  expect(commandTimeline.getTimelineOffsetForTimestamp(1500)).toBe(91.7);
   expect(commandTimeline.getTimelineOffsetForTimestamp(1510)).toBe(100);
 });
 
@@ -92,7 +93,7 @@ test('should be able to get timestamps for slices of the timeline', async () => 
   const navigations = [{ id: 1, url: '1', statusChanges: new Map() } as any] as INavigation[];
   {
     const commandTimeline = new CommandTimeline(commands, 1, navigations);
-    expect(commandTimeline.getTimelineOffsetForTimestamp(36)).toBe(86.6);
+    expect(commandTimeline.getTimelineOffsetForTimestamp(36)).toBe(86.7);
   }
   {
     const commandTimeline = new CommandTimeline(commands, 1, navigations, [35]);
@@ -107,5 +108,54 @@ test('should be able to get timestamps for slices of the timeline', async () => 
   {
     const commandTimeline = new CommandTimeline(commands, 1, navigations, [35, 45]);
     expect(commandTimeline.getTimelineOffsetForTimestamp(41)).toBe(60);
+  }
+});
+
+test('should match percentages in and out', () => {
+  const commands = [
+    {
+      clientStartDate: 1636664237736,
+      runStartDate: 1636664237738,
+      endDate: 1636664238135,
+    },
+    {
+      clientStartDate: 1636664238140,
+      runStartDate: 1636664238142,
+      endDate: 1636664238146,
+    },
+    {
+      runStartDate: 1636664238147,
+      endDate: 1636664238396,
+    },
+    {
+      runStartDate: 1636664238147,
+      endDate: 1636664238147,
+    },
+    {
+      clientStartDate: 1636664238398,
+      runStartDate: 1636664238416,
+      endDate: 1636664238417,
+    },
+    {
+      clientStartDate: 1636664238399,
+      runStartDate: 1636664238417,
+      endDate: 1636664243193,
+    },
+  ].map((x: any, i) => {
+    x.id = i + 1;
+    x.run = 0;
+    return x;
+  });
+  const timeline = new CommandTimeline(commands as any, 0, []);
+
+  const last = commands[commands.length - 1];
+  expect(timeline.startTime).toBe(commands[0].clientStartDate);
+  expect(timeline.endTime).toBe(last.endDate);
+  expect(timeline.runtimeMs).toBe(last.endDate - commands[0].clientStartDate);
+
+  for (const i of [0, 15, 14.7, 63, 78]) {
+    const timestamp = timeline.getTimestampForOffset(i);
+    const offset = timeline.getTimelineOffsetForTimestamp(timestamp);
+    expect(offset).toBe(i);
   }
 });

--- a/timetravel/test/mirrorPage.test.ts
+++ b/timetravel/test/mirrorPage.test.ts
@@ -74,7 +74,7 @@ describe('MirrorPage tests', () => {
         new Set([tab.mainFrameId]),
         tab.session.db.frames.frameDomNodePathsById,
       );
-      await mirrorPage.updateDomRecording(domRecordingUpdates);
+      await mirrorPage.addDomRecordingUpdates(domRecordingUpdates);
       await mirrorPage.load();
 
       const sourceHtmlNext = await tab.puppetPage.mainFrame.html();
@@ -178,7 +178,7 @@ describe('MirrorPage tests', () => {
         new Set([tab.mainFrameId]),
         tab.session.db.frames.frameDomNodePathsById,
       );
-      await mirrorPage.updateDomRecording(domRecordingUpdates);
+      await mirrorPage.addDomRecordingUpdates(domRecordingUpdates);
       await mirrorPage.load();
     }
 


### PR DESCRIPTION
1. Fix error message from client when no page states given
2. Convert uuid to nanoid
3. Fix issue in human-emulator where target rect could change after mouse move, but wasn't updating final point, which made the mouse "miss"
4. Fix closing bug in client where it would get in a loop
5. Fix timeline bugs related to using a different timeline range than the commands
6. Convert core/FrameNavigationObserver to support multiple observers
7. Fix issue in PageStateGenerator removing frames that don't exist in all sessions
8. Fix issues properly reloading changed PageState sessions
9. Fix issues importing PageStates from previous runs.