### PR TITLE
fix(timetravel): multi-tabs conflicting documents

### DIFF
--- a/core/injected-scripts/interactReplayer.ts
+++ b/core/injected-scripts/interactReplayer.ts
@@ -63,10 +63,7 @@ window.replayInteractions = function replayInteractions(
   scrollEvent: IFrontendScrollEvent,
 ) {
   highlightNodes(resultNodeIds);
-  const startingTracking = shouldTrackMouse;
-  shouldTrackMouse = true;
   updateMouse(mouseEvent);
-  shouldTrackMouse = startingTracking;
   updateScroll(scrollEvent);
 };
 

--- a/core/models/ScreenshotsTable.ts
+++ b/core/models/ScreenshotsTable.ts
@@ -6,6 +6,7 @@ export default class ScreenshotsTable extends SqliteTable<IScreenshot> {
   public includeWhiteScreens = false;
 
   private screenshotTimesByTabId = new Map<number, number[]>();
+  private hasLoadedCounts = false;
   private lastImageByTab: { [tabId: number]: Buffer } = {};
 
   constructor(readonly db: SqliteDatabase) {
@@ -36,7 +37,8 @@ export default class ScreenshotsTable extends SqliteTable<IScreenshot> {
   }
 
   public getScreenshotTimesByTabId(): ScreenshotsTable['screenshotTimesByTabId'] {
-    if (this.screenshotTimesByTabId.size) return this.screenshotTimesByTabId;
+    if (this.hasLoadedCounts) return this.screenshotTimesByTabId;
+    this.hasLoadedCounts = true;
     const timestamps = this.db.prepare(`select timestamp, tabId from ${this.tableName}`).all();
     for (const { timestamp, tabId } of timestamps) {
       this.trackScreenshotTime(tabId, timestamp);
@@ -60,6 +62,7 @@ export default class ScreenshotsTable extends SqliteTable<IScreenshot> {
   }
 
   private trackScreenshotTime(tabId: number, timestamp: number): void {
+    this.hasLoadedCounts = true;
     if (!this.screenshotTimesByTabId.has(tabId)) {
       this.screenshotTimesByTabId.set(tabId, []);
     }

--- a/interfaces/ITimelineMetadata.ts
+++ b/interfaces/ITimelineMetadata.ts
@@ -23,4 +23,9 @@ export default interface ITimelineMetadata {
     offsetPercent: number;
     tabId: number;
   }[];
+  storageEvents: {
+    offsetPercent: number;
+    tabId: number;
+    count: number;
+  }[];
 }

--- a/timetravel/lib/PageStateGenerator.ts
+++ b/timetravel/lib/PageStateGenerator.ts
@@ -117,7 +117,12 @@ export default class PageStateGenerator {
       };
     }
     for (const session of savedState.sessions) {
-      const db = SessionDb.getCached(session.sessionId, false);
+      let db: SessionDb;
+      try {
+        db = SessionDb.getCached(session.sessionId, false);
+      } catch (err) {
+        // couldn't load
+      }
       this.sessionsById.set(session.sessionId, {
         ...session,
         db,

--- a/timetravel/lib/TimelineBuilder.ts
+++ b/timetravel/lib/TimelineBuilder.ts
@@ -135,10 +135,25 @@ export default class TimelineBuilder {
       });
     }
 
+    const storageEvents: ITimelineMetadata['storageEvents'] = [];
+    const changesByTabId: { [tabId: number]: number } = {};
+    for (const { tabId, timestamp, count } of db.storageChanges.getChangesByTabIdAndTime()) {
+      changesByTabId[tabId] ??= 0;
+      changesByTabId[tabId] += count;
+      const offsetPercent = commandTimeline.getTimelineOffsetForTimestamp(timestamp);
+      if (offsetPercent === -1) continue;
+      storageEvents.push({
+        offsetPercent,
+        tabId,
+        count: changesByTabId[tabId],
+      });
+    }
+
     return {
       urls,
       screenshots,
       paintEvents,
+      storageEvents,
     };
   }
 }

--- a/timetravel/player/TimetravelPlayer.ts
+++ b/timetravel/player/TimetravelPlayer.ts
@@ -97,7 +97,7 @@ export default class TimetravelPlayer extends TypedEventEmitter<{
     const tab = this.activeTab;
 
     const startTick = tab.currentTick;
-    const startedOpen = this.isOpen;
+    const startedOpen = tab.isOpen;
     await this.openTab(tab);
     if (sessionOffsetPercent !== undefined) {
       await tab.setTimelineOffset(sessionOffsetPercent);
@@ -205,12 +205,12 @@ export default class TimetravelPlayer extends TypedEventEmitter<{
     });
 
     if (this.debugLogging) {
-      log.info('Replay Tab State', {
+      log.info('Timetravel Tab State', {
         sessionId: this.sessionId,
         tabDetails: ticksResult.tabDetails,
       });
     }
-
+    
     for (const tabDetails of ticksResult.tabDetails) {
       const tabPlaybackController = this.tabsById.get(tabDetails.tab.id);
       if (tabPlaybackController) {


### PR DESCRIPTION
Feature:
- Track storage changes at each tick for a timeline

Fixes: 
- Tracking mouse incorrectly for a person moving the mouse
- A second tab opened would break timetravel inside page state (was a conflict of "documents" in MirrorNetwork)
