### PR TITLE
feat(client): add serialized callstack

### DIFF
--- a/client/lib/CoreEventHeap.ts
+++ b/client/lib/CoreEventHeap.ts
@@ -56,7 +56,9 @@ export default class CoreEventHeap {
       startDate: new Date(),
       command: 'Events.addEventListener',
       args: [jsPath, type, options],
-      callsite: this.shouldIncludeCallSite() ? scriptInstance.getScriptCallSite() : null,
+      callsite: this.shouldIncludeCallSite()
+        ? JSON.stringify(scriptInstance.getScriptCallSite())
+        : null,
     });
 
     this.pendingRegistrations = this.pendingRegistrations.then(() => subscriptionPromise);
@@ -98,7 +100,9 @@ export default class CoreEventHeap {
         startDate: new Date(),
         command: 'Events.removeEventListener',
         args: [listenerId, options],
-        callsite: this.shouldIncludeCallSite() ? scriptInstance.getScriptCallSite() : null,
+        callsite: this.shouldIncludeCallSite()
+          ? JSON.stringify(scriptInstance.getScriptCallSite())
+          : null,
       })
       .catch(error => {
         log.error('removeEventListener Error: ', { error, sessionId: this.meta?.sessionId });

--- a/client/lib/Hero.ts
+++ b/client/lib/Hero.ts
@@ -238,9 +238,7 @@ export default class Hero extends AwaitedEventTarget<{
   }
 
   public detach(tab: Tab, key?: string): FrozenTab {
-    const callSitePath = getCallSite(module.filename, scriptInstance.entrypoint)
-      .map(x => `${x.getFileName()}:${x.getLineNumber()}:${x.getColumnNumber()}`)
-      .join('\n');
+    const callSitePath = JSON.stringify(getCallSite(module.filename, scriptInstance.entrypoint));
 
     const coreTab = getCoreTab(tab);
     const coreSession = getState(this).connection.getConnectedCoreSessionOrReject();

--- a/client/lib/PageState.ts
+++ b/client/lib/PageState.ts
@@ -15,6 +15,7 @@ import IPageStateDefinitions, {
 import Tab from './Tab';
 import DisconnectedFromCoreError from '../connections/DisconnectedFromCoreError';
 import { CanceledPromiseError } from '@ulixee/commons/interfaces/IPendingWaitEvent';
+import ISourceCodeLocation from '@ulixee/commons/interfaces/ISourceCodeLocation';
 
 let counter = 0;
 
@@ -27,7 +28,7 @@ export default class PageState<T extends IPageStateDefinitions, K = keyof T> {
   readonly #coreTab: CoreTab;
   readonly #tab: Tab;
   readonly #states: T;
-  readonly #callsite: string;
+  readonly #callsite: ISourceCodeLocation[];
   readonly #jsPath: IJsPath = ['page-state', (counter += 1)];
   #idCounter = 0;
 
@@ -39,7 +40,7 @@ export default class PageState<T extends IPageStateDefinitions, K = keyof T> {
   readonly #stateResolvable = new Resolvable<K>();
   readonly #batchAssertionPathToId: Record<string, string> = {};
 
-  constructor(tab: Tab, coreTab: CoreTab, states: T, callSitePath: string) {
+  constructor(tab: Tab, coreTab: CoreTab, states: T, callSitePath: ISourceCodeLocation[]) {
     this.#tab = tab;
     this.#coreTab = coreTab;
     this.#states = states ?? ({} as T);
@@ -54,7 +55,7 @@ export default class PageState<T extends IPageStateDefinitions, K = keyof T> {
     const timer = new Timer(timeoutMs);
     const pageStateOptions: IPageStateListenArgs = {
       commands: this.#rawCommandsById,
-      callsite: this.#callsite,
+      callsite: JSON.stringify(this.#callsite),
       states: Object.keys(this.#states),
     };
 

--- a/client/lib/ScriptInstance.ts
+++ b/client/lib/ScriptInstance.ts
@@ -2,6 +2,7 @@ import { nanoid } from 'nanoid';
 import IScriptInstanceMeta from '@ulixee/hero-interfaces/IScriptInstanceMeta';
 import { getCallSite } from '@ulixee/commons/lib/utils';
 import ISessionCreateOptions from '@ulixee/hero-interfaces/ISessionCreateOptions';
+import ISourceCodeLocation from '@ulixee/commons/interfaces/ISourceCodeLocation';
 
 const AwaitedDomPath = require.resolve('awaited-dom/package.json').replace('package.json', '');
 const HeroLibPath = require.resolve('./Hero').replace(/\/Hero\.(?:ts|js)/, '');
@@ -50,14 +51,14 @@ export default class ScriptInstance {
     return name;
   }
 
-  public getScriptCallSite(ignoreMode = false): string {
-    if (!ignoreMode && this.mode === 'production') return;
+  public getScriptCallSite(getCallSiteRegardlessOfMode = false): ISourceCodeLocation[] {
+    if (!getCallSiteRegardlessOfMode && this.mode === 'production') return;
     const stack = getCallSite(module.filename);
 
-    let stackLines: string[] = [];
+    let stackLines: ISourceCodeLocation[] = [];
     let lastIndexOfEntrypoint = -1;
     for (const callSite of stack) {
-      const filename = callSite.getFileName();
+      const { filename } = callSite;
       if (!filename) continue;
 
       if (filename.startsWith(HeroLibPath) || filename.startsWith(AwaitedDomPath)) continue;
@@ -65,12 +66,12 @@ export default class ScriptInstance {
         lastIndexOfEntrypoint = stackLines.length;
       }
 
-      stackLines.push(`${filename}:${callSite.getLineNumber()}:${callSite.getColumnNumber()}`);
+      stackLines.push(callSite);
     }
 
     if (lastIndexOfEntrypoint >= 0) stackLines = stackLines.slice(0, lastIndexOfEntrypoint + 1);
 
-    return stackLines.join('\n');
+    return stackLines;
   }
 }
 

--- a/client/lib/Tab.ts
+++ b/client/lib/Tab.ts
@@ -230,7 +230,6 @@ export default class Tab extends AwaitedEventTarget<IEventType> {
     states?: T,
     options: Pick<IWaitForOptions, 'timeoutMs'> = { timeoutMs: 30e3 },
   ): Promise<keyof T> {
-
     const callSitePath = scriptInstance.getScriptCallSite();
 
     const coreTab = await getCoreTab(this);

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
     "require": "./index.cjs"
   },
   "dependencies": {
-    "@ulixee/commons": "1.5.8",
+    "@ulixee/commons": "1.5.9",
     "@ulixee/hero-interfaces": "1.5.4",
     "@ulixee/hero-plugin-utils": "1.5.4",
     "awaited-dom": "1.3.0",

--- a/client/test/basic.test.ts
+++ b/client/test/basic.test.ts
@@ -89,16 +89,16 @@ describe('basic Hero tests', () => {
 
     const outgoingCommands = connectionToCore.outgoing.mock.calls;
 
-    expect(outgoingCommands.filter(c => c[0].callsite)).toHaveLength(0)
+    expect(outgoingCommands.filter(c => c[0].callsite)).toHaveLength(0);
   });
 });
 
 describe('ScriptInstance tests', () => {
   it('should be able to properly get a script location', () => {
-    expect(scriptInstance.getScriptCallSite().split(/\r?\n/)).toHaveLength(1);
+    expect(scriptInstance.getScriptCallSite()).toHaveLength(1);
 
     (function testNested() {
-      expect(scriptInstance.getScriptCallSite().split(/\r?\n/)).toHaveLength(2);
+      expect(scriptInstance.getScriptCallSite()).toHaveLength(2);
     })();
   });
 });

--- a/core/package.json
+++ b/core/package.json
@@ -16,7 +16,7 @@
     "./connections/*": "./connections/*.js"
   },
   "dependencies": {
-    "@ulixee/commons": "1.5.8",
+    "@ulixee/commons": "1.5.9",
     "@ulixee/default-browser-emulator": "1.5.4",
     "@ulixee/default-human-emulator": "1.5.4",
     "@ulixee/hero-interfaces": "1.5.4",

--- a/fullstack/package.json
+++ b/fullstack/package.json
@@ -7,7 +7,7 @@
     "require": "./index.cjs"
   },
   "dependencies": {
-    "@ulixee/commons": "1.5.8",
+    "@ulixee/commons": "1.5.9",
     "@ulixee/hero": "1.5.4",
     "@ulixee/hero-core": "1.5.4",
     "@ulixee/hero-interfaces": "1.5.4",

--- a/interfaces/package.json
+++ b/interfaces/package.json
@@ -4,7 +4,7 @@
   "description": "Core interfaces used by Hero",
   "dependencies": {
     "awaited-dom": "1.3.0",
-    "@ulixee/commons": "1.5.8",
+    "@ulixee/commons": "1.5.9",
     "devtools-protocol": "^0.0.799653"
   }
 }

--- a/mitm-socket/package.json
+++ b/mitm-socket/package.json
@@ -8,7 +8,7 @@
     "build-install": "npm run build"
   },
   "dependencies": {
-    "@ulixee/commons": "1.5.8",
+    "@ulixee/commons": "1.5.9",
     "@ulixee/hero-interfaces": "1.5.4",
     "nanoid": "^3.1.30"
   },

--- a/mitm/package.json
+++ b/mitm/package.json
@@ -4,7 +4,7 @@
   "description": "Man-in-the-middle proxy to fix chrome request/response",
   "main": "index.js",
   "dependencies": {
-    "@ulixee/commons": "1.5.8",
+    "@ulixee/commons": "1.5.9",
     "@ulixee/hero-interfaces": "1.5.4",
     "@ulixee/hero-mitm-socket": "1.5.4",
     "better-sqlite3": "^7.4.1",

--- a/plugin-utils/package.json
+++ b/plugin-utils/package.json
@@ -5,7 +5,7 @@
   "scripts": {},
   "dependencies": {
     "@ulixee/chrome-app": "1.0.2",
-    "@ulixee/commons": "1.5.8",
+    "@ulixee/commons": "1.5.9",
     "@ulixee/hero-interfaces": "1.5.4",
     "progress": "^2.0.3",
     "tar": "^6.1.11"

--- a/plugins/default-browser-emulator/package.json
+++ b/plugins/default-browser-emulator/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "@ulixee/chrome-89-0": "^4389.128.4",
-    "@ulixee/commons": "1.5.8",
+    "@ulixee/commons": "1.5.9",
     "@ulixee/hero-interfaces": "1.5.4",
     "@ulixee/hero-plugin-utils": "1.5.4",
     "compare-versions": "^3.6.0",

--- a/plugins/default-human-emulator/package.json
+++ b/plugins/default-human-emulator/package.json
@@ -8,6 +8,6 @@
     "@ulixee/hero-plugin-utils": "1.5.4"
   },
   "devDependencies": {
-    "@ulixee/commons": "1.5.8"
+    "@ulixee/commons": "1.5.9"
   }
 }

--- a/plugins/execute-js/package.json
+++ b/plugins/execute-js/package.json
@@ -8,7 +8,7 @@
     "@ulixee/hero-plugin-utils": "1.5.4"
   },
   "devDependencies": {
-    "@ulixee/commons": "1.5.8",
+    "@ulixee/commons": "1.5.9",
     "@ulixee/hero-core": "1.5.4",
     "@ulixee/hero-fullstack": "1.5.4",
     "@ulixee/execute-js-plugin": "1.5.4",

--- a/puppet-chrome/package.json
+++ b/puppet-chrome/package.json
@@ -3,7 +3,7 @@
   "version": "1.5.4",
   "description": "Puppet driver for chrome",
   "dependencies": {
-    "@ulixee/commons": "1.5.8",
+    "@ulixee/commons": "1.5.9",
     "@ulixee/hero-interfaces": "1.5.4",
     "devtools-protocol": "^0.0.799653"
   }

--- a/puppet/package.json
+++ b/puppet/package.json
@@ -3,7 +3,7 @@
   "version": "1.5.4",
   "description": "Puppet driver",
   "dependencies": {
-    "@ulixee/commons": "1.5.8",
+    "@ulixee/commons": "1.5.9",
     "@ulixee/hero-interfaces": "1.5.4",
     "@ulixee/hero-puppet-chrome": "1.5.4",
     "ws": "^7.4.6"

--- a/testing/package.json
+++ b/testing/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@koa/multer": "^3.0.0",
     "@koa/router": "^8.0.8",
-    "@ulixee/commons": "1.5.8",
+    "@ulixee/commons": "1.5.9",
     "@ulixee/hero-core": "1.5.4",
     "@ulixee/hero-interfaces": "1.5.4",
     "@ulixee/hero-mitm-socket": "1.5.4",

--- a/timetravel/package.json
+++ b/timetravel/package.json
@@ -3,7 +3,7 @@
   "version": "1.5.4",
   "description": "The interface to playback and examine previous Hero sessions",
   "dependencies": {
-    "@ulixee/commons": "1.5.8",
+    "@ulixee/commons": "1.5.9",
     "@ulixee/hero-interfaces": "1.5.4",
     "@ulixee/hero-core": "1.5.4",
     "nanoid": "^3.1.30"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7509,6 +7509,11 @@ sort-keys@^4.0.0:
   dependencies:
     is-plain-obj "^2.0.0"
 
+source-map-js@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.1.tgz#a1741c131e3c77d048252adfa24e23b908670caf"
+  integrity sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==
+
 source-map-loader@^0.2.4:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-0.2.4.tgz#c18b0dc6e23bf66f6792437557c569a11e072271"
@@ -7517,7 +7522,7 @@ source-map-loader@^0.2.4:
     async "^2.5.0"
     loader-utils "^1.1.0"
 
-source-map-support@^0.5.19, source-map-support@^0.5.6:
+source-map-support@^0.5.6:
   version "0.5.20"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.20.tgz#12166089f8f5e5e8c56926b377633392dd2cb6c9"
   integrity sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==


### PR DESCRIPTION
Use a common standard for the stacktraces we use during development.

This PR moves Hero off of using source-map-support in favor of directly using the source-map library from Mozilla. Unfortunately, they've moved to an async model that makes it difficult to support stack traces (which are synchronous). I used a fork of that library that is porting some of their performance improvements (minus wasm) (source-map-js). In a recent ticket, the mozilla lib is considering taking a PR, so we can possibly move back to that once it's up (https://github.com/mozilla/source-map/issues/370#issuecomment-823403894)