### PR TITLE
feat(core): magic selectors

### DIFF
--- a/client/lib/CoreFrameEnvironment.ts
+++ b/client/lib/CoreFrameEnvironment.ts
@@ -1,17 +1,28 @@
 import { IInteractionGroups } from '@ulixee/hero-interfaces/IInteractions';
 import ISessionMeta from '@ulixee/hero-interfaces/ISessionMeta';
 import { ILoadStatus, ILocationTrigger } from '@ulixee/hero-interfaces/Location';
-import { IJsPath } from 'awaited-dom/base/AwaitedPath';
+import AwaitedPath, { IJsPath } from 'awaited-dom/base/AwaitedPath';
 import { ICookie } from '@ulixee/hero-interfaces/ICookie';
 import IWaitForElementOptions from '@ulixee/hero-interfaces/IWaitForElementOptions';
 import IExecJsPathResult from '@ulixee/hero-interfaces/IExecJsPathResult';
 import { IRequestInit } from 'awaited-dom/base/interfaces/official';
 import INodePointer from 'awaited-dom/base/INodePointer';
 import ISetCookieOptions from '@ulixee/hero-interfaces/ISetCookieOptions';
+import { getComputedVisibilityFnName } from '@ulixee/hero-interfaces/jsPathFnNames';
 import IWaitForOptions from '@ulixee/hero-interfaces/IWaitForOptions';
 import IFrameMeta from '@ulixee/hero-interfaces/IFrameMeta';
 import CoreCommandQueue from './CoreCommandQueue';
 import IResourceMeta from '@ulixee/hero-interfaces/IResourceMeta';
+import { INodeVisibility } from '@ulixee/hero-interfaces/INodeVisibility';
+import { delegate as AwaitedHandler } from './SetupAwaitedHandler';
+import StateMachine from 'awaited-dom/base/StateMachine';
+import IAwaitedOptions from '../interfaces/IAwaitedOptions';
+import { INodeIsolate } from 'awaited-dom/base/interfaces/isolate';
+
+const awaitedPathState = StateMachine<
+  any,
+  { awaitedPath: AwaitedPath; awaitedOptions: IAwaitedOptions; nodePointer?: INodePointer }
+>();
 
 export default class CoreFrameEnvironment {
   public tabId: number;
@@ -89,6 +100,10 @@ export default class CoreFrameEnvironment {
 
   public async interact(interactionGroups: IInteractionGroups): Promise<void> {
     await this.commandQueue.run('FrameEnvironment.interact', ...interactionGroups);
+  }
+
+  public async getComputedVisibility(node: INodeIsolate): Promise<INodeVisibility> {
+    return await AwaitedHandler.runMethod(awaitedPathState, node, getComputedVisibilityFnName, []);
   }
 
   public async getCookies(): Promise<ICookie[]> {

--- a/client/lib/DomExtender.ts
+++ b/client/lib/DomExtender.ts
@@ -6,6 +6,8 @@ import SuperNode from 'awaited-dom/impl/super-klasses/SuperNode';
 import SuperHTMLElement from 'awaited-dom/impl/super-klasses/SuperHTMLElement';
 import { ITypeInteraction } from '../interfaces/IInteractions';
 import Interactor from './Interactor';
+import { INodeVisibility } from '@ulixee/hero-interfaces/INodeVisibility';
+import CoreFrameEnvironment from './CoreFrameEnvironment';
 
 const { getState } = StateMachine<ISuperElement, ISuperElementProperties>();
 
@@ -14,6 +16,7 @@ interface IBaseExtend {
     click: () => Promise<void>;
     type: (...typeInteractions: ITypeInteraction[]) => Promise<void>;
     waitForVisible: () => Promise<void>;
+    getComputedVisibility: () => Promise<INodeVisibility>;
   };
 }
 
@@ -28,12 +31,12 @@ for (const Super of [SuperElement, SuperNode, SuperHTMLElement]) {
     get: function $() {
       const click = async (): Promise<void> => {
         const { awaitedOptions } = getState(this);
-        const coreFrame = await awaitedOptions?.coreFrame;
+        const coreFrame: CoreFrameEnvironment = await awaitedOptions?.coreFrame;
         await Interactor.run(coreFrame, [{ click: this }]);
       };
       const type = async (...typeInteractions: ITypeInteraction[]): Promise<void> => {
         const { awaitedOptions } = getState(this);
-        const coreFrame = await awaitedOptions?.coreFrame;
+        const coreFrame: CoreFrameEnvironment = await awaitedOptions?.coreFrame;
         await click();
         await Interactor.run(
           coreFrame,
@@ -42,11 +45,16 @@ for (const Super of [SuperElement, SuperNode, SuperHTMLElement]) {
       };
       const waitForVisible = async (): Promise<void> => {
         const { awaitedPath, awaitedOptions } = getState(this);
-        const coreFrame = await awaitedOptions?.coreFrame;
+        const coreFrame: CoreFrameEnvironment = await awaitedOptions?.coreFrame;
         await coreFrame.waitForElement(awaitedPath.toJSON(), { waitForVisible: true });
       };
+      const getComputedVisibility = async (): Promise<void> => {
+        const { awaitedOptions } = getState(this);
+        const coreFrame: CoreFrameEnvironment = await awaitedOptions?.coreFrame;
+        await coreFrame.getComputedVisibility(this);
+      };
 
-      return { click, type, waitForVisible };
+      return { click, type, waitForVisible, getComputedVisibility };
     },
   });
 }

--- a/client/lib/Hero.ts
+++ b/client/lib/Hero.ts
@@ -10,7 +10,7 @@ import IDomStorage from '@ulixee/hero-interfaces/IDomStorage';
 import IUserProfile from '@ulixee/hero-interfaces/IUserProfile';
 import { IRequestInit } from 'awaited-dom/base/interfaces/official';
 import Response from 'awaited-dom/impl/official-klasses/Response';
-import { ISuperElement } from 'awaited-dom/base/interfaces/super';
+import { ISuperElement, ISuperNode, ISuperNodeList } from 'awaited-dom/base/interfaces/super';
 import IWaitForResourceOptions from '@ulixee/hero-interfaces/IWaitForResourceOptions';
 import IWaitForElementOptions from '@ulixee/hero-interfaces/IWaitForElementOptions';
 import { ILocationTrigger } from '@ulixee/hero-interfaces/Location';
@@ -59,6 +59,7 @@ import CoreFrameEnvironment from './CoreFrameEnvironment';
 import ConnectionManager from './ConnectionManager';
 import './DomExtender';
 import IPageStateDefinitions from '../interfaces/IPageStateDefinitions';
+import IMagicSelectorOptions from '@ulixee/hero-interfaces/IMagicSelectorOptions';
 
 export const DefaultOptions = {
   defaultBlockedResourceTypes: [BlockedResourceType.None],
@@ -378,6 +379,14 @@ export default class Hero extends AwaitedEventTarget<{
   // @deprecated 2021-04-30: Replaced with getComputedVisibility
   public async isElementVisible(element: IElementIsolate): Promise<boolean> {
     return await this.getComputedVisibility(element as any).then(x => x.isVisible);
+  }
+
+  public magicSelector(selectorOrOptions?: string | IMagicSelectorOptions): ISuperNode {
+    return this.activeTab.magicSelector(selectorOrOptions);
+  }
+
+  public magicSelectorAll(selectorOrOptions?: string | IMagicSelectorOptions): ISuperNodeList {
+    return this.activeTab.magicSelectorAll(selectorOrOptions);
   }
 
   public takeScreenshot(options?: IScreenshotOptions): Promise<Buffer> {

--- a/client/lib/SetupAwaitedHandler.ts
+++ b/client/lib/SetupAwaitedHandler.ts
@@ -103,6 +103,10 @@ export async function getAwaitedState<TClass>(
   return { awaitedPath, coreFrame: awaitedCoreFrame, awaitedOptions };
 }
 
+export function createHeroCommandAwaitedPath(command: string, args: any[]): AwaitedPath {
+  return new AwaitedPath(null, 'Hero', [command, args]);
+}
+
 export function getAwaitedPathAsMethodArg(awaitedPath: AwaitedPath): string {
   return `$$jsPath=${JSON.stringify(awaitedPath.toJSON())}`;
 }

--- a/client/lib/Tab.ts
+++ b/client/lib/Tab.ts
@@ -1,6 +1,6 @@
 import inspectInstanceProperties from 'awaited-dom/base/inspectInstanceProperties';
 import StateMachine from 'awaited-dom/base/StateMachine';
-import { ISuperElement } from 'awaited-dom/base/interfaces/super';
+import { ISuperElement, ISuperNode, ISuperNodeList } from 'awaited-dom/base/interfaces/super';
 import { IRequestInit } from 'awaited-dom/base/interfaces/official';
 import SuperDocument from 'awaited-dom/impl/super-klasses/SuperDocument';
 import Storage from 'awaited-dom/impl/official-klasses/Storage';
@@ -36,6 +36,7 @@ import Dialog from './Dialog';
 import FileChooser from './FileChooser';
 import PageState from './PageState';
 import IPageStateDefinitions from '../interfaces/IPageStateDefinitions';
+import IMagicSelectorOptions from '@ulixee/hero-interfaces/IMagicSelectorOptions';
 
 const awaitedPathState = StateMachine<
   any,
@@ -169,7 +170,7 @@ export default class Tab extends AwaitedEventTarget<IEventType> {
   }
 
   public getComputedStyle(element: IElementIsolate, pseudoElement?: string): CSSStyleDeclaration {
-    return FrameEnvironment.getComputedStyle(element, pseudoElement);
+    return this.mainFrameEnvironment.getComputedStyle(element, pseudoElement);
   }
 
   public async goto(href: string, timeoutMs?: number): Promise<Resource> {
@@ -204,7 +205,15 @@ export default class Tab extends AwaitedEventTarget<IEventType> {
   }
 
   public async getComputedVisibility(node: INodeIsolate): Promise<INodeVisibility> {
-    return await FrameEnvironment.getComputedVisibility(node);
+    return await this.mainFrameEnvironment.getComputedVisibility(node);
+  }
+
+  public magicSelector(selectorOrOptions?: string | IMagicSelectorOptions): ISuperNode {
+    return this.mainFrameEnvironment.magicSelector(selectorOrOptions);
+  }
+
+  public magicSelectorAll(selectorOrOptions?: string | IMagicSelectorOptions): ISuperNodeList {
+    return this.mainFrameEnvironment.magicSelectorAll(selectorOrOptions);
   }
 
   public async takeScreenshot(options?: IScreenshotOptions): Promise<Buffer> {

--- a/core/injected-scripts/jsPath.ts
+++ b/core/injected-scripts/jsPath.ts
@@ -431,6 +431,7 @@ class ObjectAtPath {
         results.push(-1);
       }
     }
+    return null;
   }
 
   public magicSelectorAll(options: IMagicSelectorOptions): NodeList {
@@ -458,11 +459,9 @@ class ObjectAtPath {
         results.push(-1);
       }
     }
+
     // create an empty node list if we didn't match anything
-    const emptyResult = document.querySelectorAll('Hero.Empty');
-    if (emptyResult.length !== 0)
-      throw new Error('MagicSelectorAllFailed. Could not create falsified empty resultset');
-    return emptyResult;
+    return new DocumentFragment().childNodes;
   }
 
   public toReturnError(error: Error): IExecJsPathResult {

--- a/core/injected-scripts/jsPath.ts
+++ b/core/injected-scripts/jsPath.ts
@@ -1,6 +1,7 @@
 import IExecJsPathResult from '@ulixee/hero-interfaces/IExecJsPathResult';
 import type INodePointer from 'awaited-dom/base/INodePointer';
 import IElementRect from '@ulixee/hero-interfaces/IElementRect';
+import IMagicSelectorOptions from '@ulixee/hero-interfaces/IMagicSelectorOptions';
 import IPoint from '@ulixee/hero-interfaces/IPoint';
 import { IJsPathError } from '@ulixee/hero-interfaces/IJsPathError';
 import { INodeVisibility } from '@ulixee/hero-interfaces/INodeVisibility';
@@ -225,6 +226,7 @@ class ObjectAtPath {
 
   private _obstructedByElement: Element;
   private lookupStep: IPathStep;
+  private lookupStepMagicSelectorMatches: number[];
   private lookupStepIndex = 0;
   private nodePointer: INodePointer;
 
@@ -408,6 +410,61 @@ class ObjectAtPath {
     return this;
   }
 
+  public magicSelector(options: IMagicSelectorOptions): Node {
+    const { querySelectors, minMatchingSelectors } = options;
+    const results: number[] = [];
+    this.lookupStepMagicSelectorMatches = results;
+    const candidates = new Map<Node, number>();
+    for (const selector of querySelectors) {
+      try {
+        const result = document.querySelectorAll(selector);
+        results.push(result.length);
+        if (result.length === 1) {
+          const node = result[0];
+          const count = (candidates.get(node) ?? 0) + 1;
+          candidates.set(node, count);
+          if (count >= minMatchingSelectors) {
+            return node;
+          }
+        }
+      } catch (err) {
+        results.push(-1);
+      }
+    }
+  }
+
+  public magicSelectorAll(options: IMagicSelectorOptions): NodeList {
+    const { querySelectors, minMatchingSelectors } = options;
+    const results: number[] = [];
+    this.lookupStepMagicSelectorMatches = results;
+    const countByStringifiedNodeIds = new Map<string, number>();
+    for (const selector of querySelectors) {
+      try {
+        const result = document.querySelectorAll(selector);
+        results.push(result.length);
+        const nodeIds: number[] = [];
+        for (const node of result) {
+          const nodeId = NodeTracker.watchNode(node);
+          nodeIds.push(nodeId);
+        }
+
+        const stringifiedIds = nodeIds.toString();
+        const count = (countByStringifiedNodeIds.get(stringifiedIds) ?? 0) + 1;
+        countByStringifiedNodeIds.set(stringifiedIds, count);
+        if (count >= minMatchingSelectors) {
+          return result;
+        }
+      } catch (err) {
+        results.push(-1);
+      }
+    }
+    // create an empty node list if we didn't match anything
+    const emptyResult = document.querySelectorAll('Hero.Empty');
+    if (emptyResult.length !== 0)
+      throw new Error('MagicSelectorAllFailed. Could not create falsified empty resultset');
+    return emptyResult;
+  }
+
   public toReturnError(error: Error): IExecJsPathResult {
     const pathError = <IJsPathError>{
       error: String(error),
@@ -416,6 +473,9 @@ class ObjectAtPath {
         index: this.lookupStepIndex,
       },
     };
+    if (this.lookupStepMagicSelectorMatches) {
+      pathError.pathState.magicSelectorMatches = this.lookupStepMagicSelectorMatches;
+    }
     return {
       value: null,
       pathError,

--- a/core/lib/FrameEnvironment.ts
+++ b/core/lib/FrameEnvironment.ts
@@ -17,7 +17,11 @@ import { IBoundLog } from '@ulixee/commons/interfaces/ILog';
 import INodePointer from 'awaited-dom/base/INodePointer';
 import IWaitForOptions from '@ulixee/hero-interfaces/IWaitForOptions';
 import IFrameMeta from '@ulixee/hero-interfaces/IFrameMeta';
-import { getNodeIdFnName } from '@ulixee/hero-interfaces/jsPathFnNames';
+import {
+  getNodeIdFnName,
+  runMagicSelector,
+  runMagicSelectorAll,
+} from '@ulixee/hero-interfaces/jsPathFnNames';
 import IJsPathResult from '@ulixee/hero-interfaces/IJsPathResult';
 import * as Os from 'os';
 import IPoint from '@ulixee/hero-interfaces/IPoint';
@@ -36,9 +40,10 @@ import InjectedScriptError from './InjectedScriptError';
 import { IJsPathHistory, JsPath } from './JsPath';
 import InjectedScripts from './InjectedScripts';
 import { PageRecorderResultSet } from '../injected-scripts/pageEventsRecorder';
-import { ICommandableTarget } from './CommandRunner';
+import CommandRunner, { ICommandableTarget } from './CommandRunner';
 import { IRemoteEmitFn, IRemoteEventListener } from '../interfaces/IRemoteEventListener';
 import IResourceMeta from '@ulixee/hero-interfaces/IResourceMeta';
+import IMagicSelectorOptions from '@ulixee/hero-interfaces/IMagicSelectorOptions';
 
 const { log } = Log(module);
 
@@ -152,6 +157,8 @@ export default class FrameEnvironment
       this.isDomContentLoaded,
       this.isPaintingStable,
       this.interact,
+      this.magicSelector,
+      this.magicSelectorAll,
       this.removeCookie,
       this.setCookie,
       this.setFileInputFiles,
@@ -256,7 +263,53 @@ export default class FrameEnvironment
     if (!this.navigations.top) return null;
     await this.navigationsObserver.waitForLoad(LoadStatus.DomContentLoaded);
     const containerOffset = await this.getContainerOffset();
+    if (jsPath[0] === 'Hero' && Array.isArray(jsPath[1])) {
+      const newJsPath = jsPath.slice(2);
+      const [command, args] = jsPath[1];
+      const commandRunner = new CommandRunner(command, [...args, newJsPath], {
+        FrameEnvironment: this,
+        Tab: this.tab,
+        Session: this.tab.session,
+      });
+      commandRunner.shouldRecord = false;
+      return await commandRunner.runFn();
+    }
     return await this.jsPath.exec(jsPath, containerOffset);
+  }
+
+  public async magicSelector<T>(
+    selectorOrOptions: string | IMagicSelectorOptions,
+    childJsPath: IJsPath,
+  ): Promise<IExecJsPathResult<T>> {
+    let options = (selectorOrOptions as IMagicSelectorOptions) ?? {
+      querySelectors: [],
+      minMatchingSelectors: 1,
+    };
+    if (selectorOrOptions && typeof selectorOrOptions === 'string') {
+      options = { minMatchingSelectors: 1, querySelectors: [selectorOrOptions] };
+    }
+
+    this.tab.emit('magic-selector', { options, frame: this });
+    childJsPath.unshift([runMagicSelector, options]);
+    const containerOffset = await this.getContainerOffset();
+    return await this.jsPath.exec(childJsPath, containerOffset);
+  }
+
+  public async magicSelectorAll<T>(
+    selectorOrOptions: string | IMagicSelectorOptions,
+    childJsPath: IJsPath,
+  ): Promise<IExecJsPathResult<T>> {
+    let options = (selectorOrOptions as IMagicSelectorOptions) ?? {
+      querySelectors: [],
+      minMatchingSelectors: 1,
+    };
+    if (selectorOrOptions && typeof selectorOrOptions === 'string') {
+      options = { minMatchingSelectors: 1, querySelectors: [selectorOrOptions] };
+    }
+    this.tab.emit('magic-selector-all', { options, frame: this });
+    childJsPath.unshift([runMagicSelectorAll, options]);
+    const containerOffset = await this.getContainerOffset();
+    return await this.jsPath.exec(childJsPath, containerOffset);
   }
 
   public async prefetchExecJsPaths(jsPaths: IJsPathHistory[]): Promise<IJsPathResult[]> {

--- a/core/lib/Tab.ts
+++ b/core/lib/Tab.ts
@@ -43,6 +43,7 @@ import IScreenRecordingOptions from '@ulixee/hero-interfaces/IScreenRecordingOpt
 import ScreenshotsTable from '../models/ScreenshotsTable';
 import { IStorageChangesEntry } from '../models/StorageChangesTable';
 import { IRemoteEmitFn, IRemoteEventListener } from '../interfaces/IRemoteEventListener';
+import IMagicSelectorOptions from '@ulixee/hero-interfaces/IMagicSelectorOptions';
 
 const { log } = Log(module);
 
@@ -1153,6 +1154,8 @@ export interface ITabEventParams {
   'resource-requested': IResourceMeta;
   resource: IResourceMeta;
   'websocket-message': IWebsocketResourceMessage;
+  'magic-selector': { options: IMagicSelectorOptions; frame: FrameEnvironment };
+  'magic-selector-all': { options: IMagicSelectorOptions; frame: FrameEnvironment };
 }
 
 export function stringToRegex(str: string): RegExp {

--- a/docs/main/BasicInterfaces/FrameEnvironment.md
+++ b/docs/main/BasicInterfaces/FrameEnvironment.md
@@ -256,6 +256,33 @@ Determines if an element is visible to an end user. This method checks whether a
 
 #### **Returns**: `Promise<boolean>` Whether the element is visible to an end user.
 
+### frameEnvironment.magicSelector*(stringOrOptions)* {#magic-selector}
+
+The magic selector is a drop-in replacement for document.querySelector, but it allows a pattern to be provided which can verify your selected elements match multiple queries.
+
+#### **Arguments**:
+- stringOrOptions `string` or `object`. Optional. When not provided and using Superhero, the MagicSelector designer is activated. 
+  - `string`. When a string, it will match the given selector string
+  - `object`. When an object, the following properties are options:
+    - minMatchingSelectors `number`. The minimum number of selectors in the provided list that must match.
+    - querySelectors `string[]`. The list of query selectors to match from.
+    
+#### **Returns**: [`SuperNode`](/docs/awaited-dom/super-node). A Node that satisfies the given patterns. Evaluates to null if awaited and not present.
+
+
+### frameEnvironment.magicSelectorAll*(stringOrOptions)* {#magic-selector-all}
+
+The magicSelectorAll function is a drop-in replacement for document.querySelectorAll, but it allows a pattern to be provided which can verify your selected elements match multiple queries. For this function, the full returned list of matching nodes must be the same for it to be considered a "match".
+
+#### **Arguments**:
+- stringOrOptions `string` or `object`. Optional. When not provided and using Superhero, the MagicSelector designer is activated.
+  - `string`. When a string, it will match the given selector string
+  - `object`. When an object, the following properties are options:
+    - minMatchingSelectors `number`. The minimum number of selectors in the provided list that must match.
+    - querySelectors `string[]`. The list of query selectors to match from.
+
+#### **Returns**: [`SuperNodeList`](/docs/awaited-dom/super-node-list). A NodeList that satisfies the given patterns. Returns an empty list if a resultset is not found that satisfies the constraints.
+
 ### frameEnvironment.waitForPaintingStable*(options)* {#wait-for-painting-stable}
 
 Wait for the page to be loaded such that a user can see the main content above the fold, including on javascript-rendered pages (eg, Single Page Apps). This load event works around deficiencies in using the Document "load" event, which does not always trigger, and doesn't work for Single Page Apps.

--- a/docs/main/BasicInterfaces/Hero.md
+++ b/docs/main/BasicInterfaces/Hero.md
@@ -532,6 +532,14 @@ Alias for [Tab.goto](/docs/basic-interfaces/tab#goto)
 
 Alias for [Tab.getComputedVisibility](/docs/basic-interfaces/tab#get-computed-visibility)
 
+### hero.magicSelector*(stringOrOptions)* {#magic-selector}
+
+Alias for [Tab.magicSelector](/docs/basic-interfaces/tab#magic-selector)
+
+### hero.magicSelectorAll*(stringOrOptions)* {#magic-selector-all}
+
+Alias for [Tab.magicSelectorAll](/docs/basic-interfaces/tab#magic-selector-all)
+
 ### hero.reload*(timeoutMs?)* {#reload}
 
 Alias for [Tab.reload](/docs/basic-interfaces/tab#reload)

--- a/docs/main/BasicInterfaces/Tab.md
+++ b/docs/main/BasicInterfaces/Tab.md
@@ -278,6 +278,33 @@ Alias for [tab.mainFrameEnvironment.getComputedVisibility](/docs/basic-interface
   - hasCssVisibility `boolean`. The visibility `style` property is not "hidden".
   - hasDimensions `boolean`. The node has width and height.
   - isUnobstructedByOtherElements `boolean`. The node is not hidden or obscured > 50% by another element.
+  
+### tab.magicSelector*(stringOrOptions)* {#magic-selector}
+
+The magic selector is a drop-in replacement for document.querySelector, but it allows a pattern to be provided which can verify your selected elements match multiple queries.
+
+#### **Arguments**:
+- stringOrOptions `string` or `object`. Optional. When not provided and using Superhero, the MagicSelector designer is activated.
+  - `string`. When a string, it will match the given selector string
+  - `object`. When an object, the following properties are options:
+    - minMatchingSelectors `number`. The minimum number of selectors in the provided list that must match.
+    - querySelectors `string[]`. The list of query selectors to match from.
+
+#### **Returns**: [`SuperNode`](/docs/awaited-dom/super-node). A Node that satisfies the given patterns. Evaluates to null if awaited and not present.
+
+
+### tab.magicSelectorAll*(stringOrOptions)* {#magic-selector-all}
+
+The magicSelectorAll function is a drop-in replacement for document.querySelectorAll, but it allows a pattern to be provided which can verify your selected elements match multiple queries. For this function, the full returned list of matching nodes must be the same for it to be considered a "match".
+
+#### **Arguments**:
+- stringOrOptions `string` or `object`. Optional. When not provided and using Superhero, the MagicSelector designer is activated.
+  - `string`. When a string, it will match the given selector string
+  - `object`. When an object, the following properties are options:
+    - minMatchingSelectors `number`. The minimum number of selectors in the provided list that must match.
+    - querySelectors `string[]`. The list of query selectors to match from.
+
+#### **Returns**: [`SuperNodeList`](/docs/awaited-dom/super-node-list). A NodeList that satisfies the given patterns. Returns an empty list if a resultset is not found that satisfies the constraints.
 
 ### tab.reload*(timeoutMs?)* {#reload}
 

--- a/fullstack/test/document.test.ts
+++ b/fullstack/test/document.test.ts
@@ -551,6 +551,7 @@ describe('Magic Selectors', () => {
     const hero = await openBrowser(`/magic2`);
 
     await expect(hero.magicSelector('.inner').innerText).rejects.toThrow();
+    await expect(hero.magicSelector('.inner')).resolves.toBe(null);
     await hero.close();
   });
 

--- a/interfaces/IJsPathError.ts
+++ b/interfaces/IJsPathError.ts
@@ -5,5 +5,6 @@ export interface IJsPathError {
   pathState: {
     step: IPathStep;
     index: number;
+    magicSelectorMatches?: number[];
   };
 }

--- a/interfaces/IMagicSelectorOptions.ts
+++ b/interfaces/IMagicSelectorOptions.ts
@@ -1,0 +1,4 @@
+export default interface IMagicSelectorOptions {
+  minMatchingSelectors: number;
+  querySelectors: string[];
+}

--- a/interfaces/jsPathFnNames.ts
+++ b/interfaces/jsPathFnNames.ts
@@ -3,6 +3,8 @@ const getClientRectFnName = '__getClientRect__';
 const getComputedVisibilityFnName = '__getComputedVisibility__';
 const getComputedStyleFnName = '__getComputedStyle__';
 const getNodeIdFnName = '__getNodeId__';
+const runMagicSelector = '__magicSelector__';
+const runMagicSelectorAll = '__magicSelectorAll__';
 
 export {
   getNodePointerFnName,
@@ -10,4 +12,6 @@ export {
   getNodeIdFnName,
   getComputedStyleFnName,
   getComputedVisibilityFnName,
+  runMagicSelector,
+  runMagicSelectorAll,
 };


### PR DESCRIPTION
NOTE: we should merge Pull Request 54 and 55 first.

This PR adds 2 functions to frameEnvironment/tab/hero:

magicSelector and magicSelectorAll
These functions on their own simply allow a user to provide a list of selectors and verify that a querySelector (or querySelectorAll) returns the same elements from the provided list of querySelectors.

When a magicSelector is encountered, an event is broadcast at a tab level (magic-selector/magic-selector-all) with the options provided. Those options can be manipulated if need by (eg, by Superhero) to provide a larger list of querySelectors to test, or to trigger UI changes in Superhero.