### PR TITLE
Wait for visible

### DIFF
--- a/client/lib/DomExtender.ts
+++ b/client/lib/DomExtender.ts
@@ -26,7 +26,7 @@ const awaitedPathState = StateMachine<
 interface IBaseExtend {
   $click: (verification?: IElementInteractVerification) => Promise<void>;
   $type: (...typeInteractions: ITypeInteraction[]) => Promise<void>;
-  $waitForVisible: (timeoutMs?: number) => Promise<ISuperElement>;
+  $waitForVisible: (options?: { timeoutMs?: number }) => Promise<ISuperElement>;
   $getComputedVisibility: () => Promise<INodeVisibility>;
 }
 

--- a/core/injected-scripts/jsPath.ts
+++ b/core/injected-scripts/jsPath.ts
@@ -4,7 +4,7 @@ import IElementRect from '@ulixee/hero-interfaces/IElementRect';
 import IMagicSelectorOptions from '@ulixee/hero-interfaces/IMagicSelectorOptions';
 import IPoint from '@ulixee/hero-interfaces/IPoint';
 import { IJsPathError } from '@ulixee/hero-interfaces/IJsPathError';
-import { INodeVisibility } from '@ulixee/hero-interfaces/INodeVisibility';
+import { INodeVisibility, INodeVisibilityOptions } from '@ulixee/hero-interfaces/INodeVisibility';
 import { IJsPath, IPathStep } from 'awaited-dom/base/AwaitedPath';
 
 const pointerFnName = '__getNodePointer__';
@@ -170,7 +170,7 @@ class JsPath {
   public static async waitForElement(
     jsPath: IJsPath,
     containerOffset: IPoint,
-    waitForVisible: boolean,
+    waitForVisible: INodeVisibilityOptions,
     timeoutMillis: number,
   ): Promise<IExecJsPathResult<INodeVisibility>> {
     const objectAtPath = new ObjectAtPath(jsPath, containerOffset);
@@ -188,10 +188,17 @@ class JsPath {
           };
           if (isElementValid && waitForVisible) {
             visibility = objectAtPath.getComputedVisibility();
-            isElementValid = visibility.isVisible;
+            for (const [key, value] of Object.entries(visibility)) {
+              if (key === 'isVisible' || typeof value !== 'boolean') continue;
+              const isRequired = key in waitForVisible ? waitForVisible[key] : true;
+              if (value === false && isRequired) {
+                isElementValid = false;
+              }
+            }
           }
 
           if (isElementValid) {
+            visibility.isVisible = true;
             return {
               nodePointer: objectAtPath.extractNodePointer(),
               value: visibility,

--- a/core/lib/FrameEnvironment.ts
+++ b/core/lib/FrameEnvironment.ts
@@ -14,6 +14,7 @@ import { IPuppetFrame, IPuppetFrameEvents } from '@ulixee/hero-interfaces/IPuppe
 import { CanceledPromiseError } from '@ulixee/commons/interfaces/IPendingWaitEvent';
 import ISetCookieOptions from '@ulixee/hero-interfaces/ISetCookieOptions';
 import { IBoundLog } from '@ulixee/commons/interfaces/ILog';
+import TimeoutError from '@ulixee/commons/interfaces/TimeoutError';
 import INodePointer from 'awaited-dom/base/INodePointer';
 import IWaitForOptions from '@ulixee/hero-interfaces/IWaitForOptions';
 import IFrameMeta from '@ulixee/hero-interfaces/IFrameMeta';
@@ -496,7 +497,8 @@ b) Use the UserProfile feature to set cookies for 1 or more domains before they'
     } finally {
       timer.clear();
     }
-    return null;
+
+    throw new TimeoutError(timeoutMessage);
   }
 
   public async flushPageEventsRecorder(): Promise<boolean> {

--- a/core/lib/JsPath.ts
+++ b/core/lib/JsPath.ts
@@ -4,7 +4,7 @@ import IWindowOffset from '@ulixee/hero-interfaces/IWindowOffset';
 import TypeSerializer from '@ulixee/commons/lib/TypeSerializer';
 import { IBoundLog } from '@ulixee/commons/interfaces/ILog';
 import Log from '@ulixee/commons/lib/Logger';
-import { INodeVisibility } from '@ulixee/hero-interfaces/INodeVisibility';
+import { INodeVisibility, INodeVisibilityOptions } from '@ulixee/hero-interfaces/INodeVisibility';
 import INodePointer from 'awaited-dom/base/INodePointer';
 import IJsPathResult from '@ulixee/hero-interfaces/IJsPathResult';
 import IPoint from '@ulixee/hero-interfaces/IPoint';
@@ -99,16 +99,28 @@ export class JsPath {
   public waitForElement(
     jsPath: IJsPath,
     containerOffset: IPoint,
-    waitForVisible: boolean,
+    waitForVisible: boolean | Omit<INodeVisibilityOptions, 'nodeExists'>,
     timeoutMillis: number,
   ): Promise<IExecJsPathResult<INodeVisibility>> {
     if (this.isMagicSelectorPath(jsPath)) this.emitMagicSelector(jsPath[0] as any);
+
+    let visibilityOptions: INodeVisibilityOptions = undefined;
+    if (typeof waitForVisible === 'object') {
+      visibilityOptions = waitForVisible as INodeVisibilityOptions;
+    } else if (waitForVisible === true) {
+      // by default, don't require on-screen
+      visibilityOptions = {
+        isOnscreenHorizontal: false,
+        isOnscreenVertical: false,
+        isUnobstructedByOtherElements: false,
+      };
+    }
 
     return this.runJsPath<INodeVisibility>(
       `waitForElement`,
       jsPath,
       containerOffset,
-      waitForVisible,
+      visibilityOptions,
       timeoutMillis,
     );
   }

--- a/core/test/waitForElement.test.ts
+++ b/core/test/waitForElement.test.ts
@@ -75,6 +75,30 @@ describe('basic waitForElement tests', () => {
     });
   });
 
+  it('can customize which options to waitForVisible', async () => {
+    koaServer.get('/waitForElementTestCustom', ctx => {
+      ctx.body = `<body>
+    <a id="waitToShow" href="/anywhere" style="margin-top:2500px; display: none">Link</a>
+<script>
+    setTimeout(function() {
+      document.querySelector('a#waitToShow').style.display = 'block';
+    }, 150);
+</script>
+</body>`;
+    });
+    const { tab } = await createSession();
+    await tab.goto(`${koaServer.baseUrl}/waitForElementTestCustom`);
+
+    await expect(
+      tab.waitForElement(['document', ['querySelector', 'a#waitToShow']], {
+        waitForVisible: { isOnscreenVertical: false },
+      }),
+    ).resolves.toMatchObject({
+      id: expect.any(Number),
+      type: 'HTMLAnchorElement',
+    });
+  });
+
   it('will yield an error for a bad querySelector', async () => {
     koaServer.get('/waitForElementBadQs', ctx => {
       ctx.body = `<body><div>Middle</div></body>`;

--- a/docs/main/BasicInterfaces/FrameEnvironment.md
+++ b/docs/main/BasicInterfaces/FrameEnvironment.md
@@ -306,7 +306,7 @@ Wait until a specific element is present in the dom.
 - element [`SuperElement`](/docs/awaited-dom/super-element)
 - options `object` Accepts any of the following:
   - timeoutMs `number`. Timeout in milliseconds. Default `30,000`.
-  - waitForVisible `boolean`. Wait until this element is visible to a user (see [getComputedVisibility](#get-computed-visility).
+  - waitForVisible `boolean` | `object`. Wait until this element is visible to a user (see [getComputedVisibility](#get-computed-visibility). If a boolean is provided, the visibility check ensures that all `getComputedVisibility` attributes are true EXCEPT onscreen and obstructions. You can provide an object containing the `getComputedVisibility` properties you would like to ignore or include. A value of `false` means the property will be ignored - for instance `{ isOnscreenVertical: false }` will ignore the onscreen vertical check. It will *not* ensure the node is not on screen vertically.
 
 #### **Returns**: `Promise`
 

--- a/docs/main/BasicInterfaces/Tab.md
+++ b/docs/main/BasicInterfaces/Tab.md
@@ -340,7 +340,7 @@ Alias for [tab.mainFrameEnvironment.waitForElement](/docs/basic-interfaces/frame
 - element [`SuperElement`](/docs/awaited-dom/super-element)
 - options `object` Accepts any of the following:
   - timeoutMs `number`. Timeout in milliseconds. Default `30,000`.
-  - waitForVisible `boolean`. Wait until this element is visible to a user (see [getComputedVisibility](#get-computed-visibility).
+  - waitForVisible `boolean` | `object`. Wait until this element is visible to a user (see [getComputedVisibility](#get-computed-visibility). If a boolean is provided, the visibility check ensures that all `getComputedVisibility` attributes are true EXCEPT onscreen and obstructions. You can provide an object containing the `getComputedVisibility` properties you would like to ignore or include. A value of `false` means the property will be ignored - for instance `{ isOnscreenVertical: false }` will ignore the onscreen vertical check. It will *not* ensure the node is not on screen vertically.
 
 #### **Returns**: `Promise`
 

--- a/interfaces/INodeVisibility.ts
+++ b/interfaces/INodeVisibility.ts
@@ -16,3 +16,16 @@ export interface INodeVisibility {
   isUnobstructedByOtherElements?: boolean;
   boundingClientRect?: IElementRect;
 }
+
+export type INodeVisibilityOptions = Pick<
+  INodeVisibility,
+  | 'nodeExists'
+  | 'isConnected'
+  | 'isOnscreenVertical'
+  | 'isOnscreenHorizontal'
+  | 'hasCssDisplay'
+  | 'hasCssVisibility'
+  | 'hasCssOpacity'
+  | 'hasDimensions'
+  | 'isUnobstructedByOtherElements'
+>;

--- a/interfaces/IWaitForElementOptions.ts
+++ b/interfaces/IWaitForElementOptions.ts
@@ -1,5 +1,6 @@
 import IWaitForOptions from './IWaitForOptions';
+import { INodeVisibilityOptions } from './INodeVisibility';
 
 export default interface IWaitForElementOptions extends IWaitForOptions {
-  waitForVisible?: boolean;
+  waitForVisible?: boolean | Omit<INodeVisibilityOptions, 'nodeExists'>;
 }

--- a/plugins/default-human-emulator/index.ts
+++ b/plugins/default-human-emulator/index.ts
@@ -503,6 +503,8 @@ export default class DefaultHumanEmulator extends HumanEmulator {
       let y: number;
       if (obstructedByElementRect.y - maxHeight > 0) {
         y = obstructedByElementRect.y - maxHeight;
+      } else if (obstructedByElementRect.y - (targetRect.height + 2) > 0) {
+        y = obstructedByElementRect.y - targetRect.height - 2;
       } else {
         // move beyond the bottom of the obstruction
         y = obstructedByElementRect.y - obstructedByElementRect.height + 2;
@@ -511,6 +513,10 @@ export default class DefaultHumanEmulator extends HumanEmulator {
         ...interactionStep,
         mousePosition: [targetRect.x, y],
       };
+      helper.logger.info('Scrolling to avoid obstruction', {
+        obstructedByElementRect,
+        scrollBeyondObstruction,
+      });
       await this.scroll(scrollBeyondObstruction, runFn, helper);
       return interactionStep.mousePosition;
     }


### PR DESCRIPTION
Allows customizing the waitForVisible and waitForElement functions to specific individual properties of getComputedVisibility. By default, we now ignore isOnscreen* and isUnobstructed properties when determining if an element is "visible"