### PR TITLE
fix(client): wait for command flush

### DIFF
--- a/client/lib/CoreCommandQueue.ts
+++ b/client/lib/CoreCommandQueue.ts
@@ -37,6 +37,7 @@ export default class CoreCommandQueue {
   private readonly meta: ISessionMeta;
   private readonly connection: ConnectionToCore;
   private flushOnTimeout: NodeJS.Timeout;
+  private flushes: Promise<any>[] = [];
 
   private get internalQueue(): Queue {
     return this.internalState.queue;
@@ -94,13 +95,19 @@ export default class CoreCommandQueue {
     const recordCommands = [...this.internalState.commandsToRecord];
     this.internalState.commandsToRecord.length = 0;
 
-    await this.connection.sendRequest({
+    const flush = this.connection.sendRequest({
       meta: this.meta,
       command: 'Session.flush',
       startDate: new Date(),
       args: [],
       recordCommands,
     });
+    this.flushes.push(flush);
+    // wait for all pending flushes
+    await Promise.all(this.flushes);
+
+    const idx = this.flushes.indexOf(flush);
+    if (idx >= 0) this.flushes.splice(idx, 1);
   }
 
   public async runOutOfBand<T>(command: string, ...args: any[]): Promise<T> {
@@ -176,6 +183,7 @@ export default class CoreCommandQueue {
   }
 
   public stop(cancelError: CanceledPromiseError): void {
+    clearTimeout(this.flushOnTimeout);
     this.internalQueue.stop(cancelError);
   }
 


### PR DESCRIPTION
When there are lots of detached commands or output to record, we could lose changes during close.