### PR TITLE
feat: added some more dom extenders

### DIFF
--- a/client/index.mjs
+++ b/client/index.mjs
@@ -16,8 +16,14 @@ const {
   XPathResult,
   LocationStatus,
   LocationTrigger,
+  ISuperDocument,
   ISuperElement,
   ISuperNode,
+  ISuperNodeList,
+  ISuperHTMLCollection,
+  ISuperText,
+  ISuperStyleSheet,
+  ISuperHTMLElement,
 } = cjsImport;
 
 export {
@@ -36,8 +42,14 @@ export {
   XPathResult,
   LocationStatus,
   LocationTrigger,
+  ISuperDocument,
   ISuperElement,
   ISuperNode,
+  ISuperNodeList,
+  ISuperHTMLCollection,
+  ISuperText,
+  ISuperStyleSheet,
+  ISuperHTMLElement,
 };
 
 export default cjsImport.default;

--- a/client/index.ts
+++ b/client/index.ts
@@ -1,6 +1,6 @@
 // setup must go first
 import './lib/SetupAwaitedHandler';
-import { ISuperElement, ISuperNode } from "awaited-dom/base/interfaces/super";
+import { ISuperDocument, ISuperElement, ISuperNode, ISuperNodeList, ISuperHTMLCollection, ISuperText, ISuperStyleSheet, ISuperHTMLElement } from "awaited-dom/base/interfaces/super";
 import { BlockedResourceType } from '@ulixee/hero-interfaces/ITabOptions';
 import { KeyboardKey } from '@ulixee/hero-interfaces/IKeyboardLayoutUS';
 import IResourceType, { ResourceType } from '@ulixee/hero-interfaces/IResourceType';
@@ -32,6 +32,12 @@ export {
   LocationTrigger,
   IHeroCreateOptions,
   IConnectionToCoreOptions,
+  ISuperDocument,
   ISuperElement,
   ISuperNode,
+  ISuperNodeList,
+  ISuperHTMLCollection,
+  ISuperText,
+  ISuperStyleSheet,
+  ISuperHTMLElement,
 };


### PR DESCRIPTION
- Renamed $getComputedVisibility() to a $computedVisibility getter.
- Added $clearValue() to clear an input text field
- Added $map for NodeList and HTMLCollection. There are many times during extraction where you want to use querySelectorAll to grab multiple elements and then extract from all of them. Being forced to use a for loop every time is frustrating.