### PR TITLE
fix(interaction): cancel mouse clicks on mousedown

### DIFF
--- a/client/lib/FrameEnvironment.ts
+++ b/client/lib/FrameEnvironment.ts
@@ -202,7 +202,7 @@ export default class FrameEnvironment {
   }
 
   public async getComputedVisibility(node: INodeIsolate): Promise<INodeVisibility> {
-    if (!node) return { isVisible: false, nodeExists: false };
+    if (!node) return { isVisible: false, nodeExists: false, isClickable: false };
     const coreFrame = await getCoreFrameEnvironment(this);
     return await coreFrame.getComputedVisibility(node);
   }

--- a/client/lib/FrozenFrameEnvironment.ts
+++ b/client/lib/FrozenFrameEnvironment.ts
@@ -164,7 +164,7 @@ export default class FrozenFrameEnvironment {
   }
 
   public async getComputedVisibility(node: INodeIsolate): Promise<INodeVisibility> {
-    if (!node) return { isVisible: false, nodeExists: false };
+    if (!node) return { isVisible: false, nodeExists: false, isClickable: false };
     return await AwaitedHandler.delegate.runMethod<INodeVisibility, INodeIsolate>(
       awaitedPathState,
       node,

--- a/core/lib/JsPath.ts
+++ b/core/lib/JsPath.ts
@@ -105,12 +105,6 @@ export class JsPath {
   ): Promise<IExecJsPathResult<INodeVisibility>> {
     if (this.isMagicSelectorPath(jsPath)) this.emitMagicSelector(jsPath[0] as any);
 
-    options.ignoreVisibilityAttributes ??= [
-      'isOnscreenVertical',
-      'isOnscreenHorizontal',
-      'isUnobstructedByOtherElements',
-    ];
-
     return this.runJsPath<INodeVisibility>(
       `waitForElement`,
       jsPath,

--- a/core/lib/MouseListener.ts
+++ b/core/lib/MouseListener.ts
@@ -1,8 +1,8 @@
-import IMouseUpResult from '@ulixee/hero-interfaces/IMouseUpResult';
+import IMouseResult from '@ulixee/hero-interfaces/IMouseResult';
 import FrameEnvironment from './FrameEnvironment';
 import { INodeVisibility } from '@ulixee/hero-interfaces/INodeVisibility';
 
-export default class MouseupListener {
+export default class MouseListener {
   private readonly frameEnvironment: FrameEnvironment;
   private readonly nodeId: number;
 
@@ -20,8 +20,8 @@ export default class MouseupListener {
     );
   }
 
-  public async didTriggerMouseEvent(): Promise<IMouseUpResult> {
-    return await this.frameEnvironment.runIsolatedFn<IMouseUpResult>(
+  public async didTriggerMouseEvent(): Promise<IMouseResult> {
+    return await this.frameEnvironment.runIsolatedFn<IMouseResult>(
       'HERO.MouseEvents.didTrigger',
       this.nodeId,
     );

--- a/core/models/ResourcesTable.ts
+++ b/core/models/ResourcesTable.ts
@@ -218,9 +218,12 @@ export default class ResourcesTable extends SqliteTable<IResourcesRecord> {
 
   public filter(filters: { hasResponse?: boolean; isGetOrDocument?: boolean }): IResourceSummary[] {
     const { hasResponse, isGetOrDocument } = filters;
+
+    const useResourceBody = hasResponse ? 'responseData is not null' : '1=1';
     const records = this.db
       .prepare(
-        `select frameId, requestUrl, responseUrl, statusCode, requestMethod, id, tabId, type, redirectedToUrl, responseHeaders from ${this.tableName}`,
+        `select frameId, requestUrl, responseUrl, statusCode, requestMethod, id, tabId, type, redirectedToUrl, responseHeaders 
+from ${this.tableName} where ${useResourceBody}`,
       )
       .all();
 
@@ -230,7 +233,7 @@ export default class ResourcesTable extends SqliteTable<IResourcesRecord> {
           return false;
         if (isGetOrDocument && resource.requestMethod !== 'GET') {
           // if this is a POST of a document, allow it
-          if (resource.type !== 'Document' && resource.method === 'POST') return false;
+          if (resource.type !== 'Document') return false;
         }
         return true;
       })

--- a/core/test/user-profile.test.ts
+++ b/core/test/user-profile.test.ts
@@ -343,6 +343,7 @@ document.querySelector('#local').innerHTML = localStorage.getItem('test');
         mousePosition: ['window', 'document', ['querySelector', 'a']],
       },
     ]);
+    await tab.waitForLocation('change');
 
     const localContent = await tab.execJsPath([
       'document',

--- a/docs/main/BasicInterfaces/FrameEnvironment.md
+++ b/docs/main/BasicInterfaces/FrameEnvironment.md
@@ -214,11 +214,12 @@ Alias for [tab.mainFrameEnvironment.getComputedVisibility](/docs/basic-interface
 #### **Returns**: `Promise<INodeVisibility>` Boolean values indicating if the node (or closest element) is visible to an end user.
 
 - INodeVisibility `object`
-  - isVisible `boolean`. Is the node ultimately visible (convenience sum of other properties).
-  - isFound `boolean`. Was the node found in the DOM.
+  - isVisible `boolean`. The node is visible (`nodeExists`, `hasContainingElement`, `isConnected`, `hasCssOpacity`,`hasCssDisplay`,`hasCssVisibility` `hasDimensions`).
+  - isClickable `boolean`. The node is visible, in the viewport and unobstructed (`isVisible`, `isOnscreenVertical`, `isOnscreenHorizontal` and `isUnobstructedByOtherElements`).
+  - nodeExists `boolean`. Was the node found in the DOM.
   - isOnscreenVertical `boolean`. The node is on-screen vertically.
   - isOnscreenHorizontal `boolean`. The node is on-screen horizontally.
-  - hasContainingElement `boolean`. The node is an element or has a containing Element providing layout.
+  - hasContainingElement `boolean`. The node is an Element or has a containing Element providing layout.
   - isConnected `boolean`. The node is connected to the DOM.
   - hasCssOpacity `boolean`. The display `opacity` property is not "0".
   - hasCssDisplay `boolean`. The display `display` property is not "none".
@@ -307,8 +308,8 @@ Wait until a specific element is present in the dom.
 - options `object` Accepts any of the following:
   - timeoutMs `number`. Timeout in milliseconds. Default `30,000`.
   - waitForVisible `boolean`. Wait until this element is visible to a user (see [getComputedVisibility](#get-computed-visibility). 
-  - waitForHidden `boolean`. Wait until this element is hidden to a user (see [getComputedVisibility](#get-computed-visibility - all attributes must be false except any properties specified in `ignoreVisibilityAttributes`).
-  - ignoreVisibilityAttributes `string[]`. Accepts an array of keys from [getComputedVisibility](#get-computed-visibility). Defaults to ['isOnscreenVertical','isOnscreenHorizontal','isUnobstructedByOtherElements'].
+  - waitForHidden `boolean`. Wait until this element is hidden to a user (see [getComputedVisibility](#get-computed-visibility).
+  - waitForClickable `boolean`. Wait until this element is visible to a user, int the viewport, and unobstructed (see [getComputedVisibility](#get-computed-visibility).
 
 #### **Returns**: `Promise`
 

--- a/docs/main/BasicInterfaces/Tab.md
+++ b/docs/main/BasicInterfaces/Tab.md
@@ -267,8 +267,9 @@ Alias for [tab.mainFrameEnvironment.getComputedVisibility](/docs/basic-interface
 #### **Returns**: `Promise<INodeVisibility>` Boolean values indicating if the node (or closest element) is visible to an end user.
 
 - INodeVisibility `object`
-  - isVisible `boolean`. Is the node ultimately visible.
-  - isFound `boolean`. Was the node found in the DOM.
+  - isVisible `boolean`. The node is visible (`nodeExists`, `hasContainingElement`, `isConnected`, `hasCssOpacity`,`hasCssDisplay`,`hasCssVisibility` `hasDimensions`).
+  - isClickable `boolean`. The node is visible, in the viewport and unobstructed (`isVisible`, `isOnscreenVertical`, `isOnscreenHorizontal` and `isUnobstructedByOtherElements`).
+  - nodeExists `boolean`. Was the node found in the DOM.
   - isOnscreenVertical `boolean`. The node is on-screen vertically.
   - isOnscreenHorizontal `boolean`. The node is on-screen horizontally.
   - hasContainingElement `boolean`. The node is an Element or has a containing Element providing layout.
@@ -340,9 +341,9 @@ Alias for [tab.mainFrameEnvironment.waitForElement](/docs/basic-interfaces/frame
 - element [`SuperElement`](/docs/awaited-dom/super-element)
 - options `object` Accepts any of the following:
   - timeoutMs `number`. Timeout in milliseconds. Default `30,000`.
-  - waitForVisible `boolean`. Wait until this element is visible to a user (see [getComputedVisibility](#get-computed-visibility) - all attributes must be `true` except any properties specified in `ignoreVisibilityAttributes`).
-  - waitForHidden `boolean`. Wait until this element is hidden to a user (see [getComputedVisibility](#get-computed-visibility) - all attributes must be `false` except any properties specified in `ignoreVisibilityAttributes`).
-  - ignoreVisibilityAttributes `string[]`. Accepts an array of keys from [getComputedVisibility](#get-computed-visibility). Defaults to ['isOnscreenVertical','isOnscreenHorizontal','isUnobstructedByOtherElements'].
+  - waitForVisible `boolean`. Wait until this element is visible to a user (see [getComputedVisibility](#get-computed-visibility).
+  - waitForHidden `boolean`. Wait until this element is hidden to a user (see [getComputedVisibility](#get-computed-visibility).
+  - waitForClickable `boolean`. Wait until this element is visible to a user, int the viewport, and unobstructed (see [getComputedVisibility](#get-computed-visibility).
 
 #### **Returns**: `Promise`
 

--- a/fullstack/test/document.test.ts
+++ b/fullstack/test/document.test.ts
@@ -320,7 +320,8 @@ describe('basic Document tests', () => {
     await expect(
       hero.getComputedVisibility(document.querySelector('#elem-8')),
     ).resolves.toMatchObject({
-      isVisible: false,
+      isVisible: true,
+      isClickable: false,
       isUnobstructedByOtherElements: false,
     });
   });

--- a/fullstack/test/tab.test.ts
+++ b/fullstack/test/tab.test.ts
@@ -46,6 +46,7 @@ describe('Multi-tab scenarios', () => {
     expect(await document.querySelector('#newTabHeader').textContent).toBe('You are here');
 
     await hero.click(hero.document.querySelector('a'));
+    await hero.waitForLocation('change');
     expect(await hero.activeTab.url).toBe(`${koaServer.baseUrl}/newTab#hash`);
 
     const meta = await hero.meta;
@@ -155,6 +156,7 @@ describe('Multi-tab scenarios', () => {
     expect(await document.querySelector('#newTabHeader').textContent).toBe('You are here');
 
     await hero.click(document.querySelector('a'));
+    await hero.waitForLocation('change');
     expect(await hero.activeTab.url).toBe(`${koaServer.baseUrl}/newTab#hash`);
 
     const meta = await hero.meta;

--- a/interfaces/IInteractions.ts
+++ b/interfaces/IInteractions.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { IJsPath } from 'awaited-dom/base/AwaitedPath';
 import { IKeyboardKeyCode } from './IKeyboardLayoutUS';
+import IMouseResult from './IMouseResult';
 import IPoint from './IPoint';
 
 export type IElementInteractVerification = 'elementAtPath' | 'exactElement' | 'none';
@@ -14,6 +15,7 @@ export interface IInteractionStep {
   command: IInteractionCommand;
   mousePosition?: IMousePosition;
   mouseButton?: IMouseButton;
+  mouseResultVerifier?: () => Promise<IMouseResult>;
   simulateOptionClickOnNodeId?: number;
   keyboardCommands?: IKeyboardCommand[];
   keyboardDelayBetween?: number;

--- a/interfaces/IInteractionsHelper.ts
+++ b/interfaces/IInteractionsHelper.ts
@@ -1,5 +1,5 @@
 import { IBoundLog } from '@ulixee/commons/interfaces/ILog';
-import type IMouseUpResult from './IMouseUpResult';
+import IMouseResult from './IMouseResult';
 import { IMousePosition } from './IInteractions';
 import IRect from './IRect';
 import IPoint from './IPoint';
@@ -13,9 +13,9 @@ export default interface IInteractionsHelper {
   viewportSize: IViewportSize;
   logger: IBoundLog;
 
-  createMouseupTrigger(nodeId: number): Promise<{
+  createMousedownTrigger(nodeId: number): Promise<{
     nodeVisibility: INodeVisibility;
-    didTrigger: () => Promise<IMouseUpResult>;
+    didTrigger: () => Promise<IMouseResult>;
   }>;
 
   reloadJsPath(jsPath: IJsPath): Promise<INodePointer>;

--- a/interfaces/IMouseResult.ts
+++ b/interfaces/IMouseResult.ts
@@ -1,6 +1,6 @@
 import { INodeVisibility } from './INodeVisibility';
 
-export default interface IMouseUpResult {
+export default interface IMouseResult {
   pageX: number;
   pageY: number;
   targetNodeId: number;

--- a/interfaces/INodeVisibility.ts
+++ b/interfaces/INodeVisibility.ts
@@ -1,7 +1,8 @@
 import IElementRect from './IElementRect';
 
 export interface INodeVisibility {
-  isVisible?: boolean;
+  isVisible: boolean;
+  isClickable: boolean;
   nodeExists?: boolean;
   isOnscreenVertical?: boolean;
   isOnscreenHorizontal?: boolean;
@@ -16,16 +17,3 @@ export interface INodeVisibility {
   isUnobstructedByOtherElements?: boolean;
   boundingClientRect?: IElementRect;
 }
-
-export type INodeVisibilityAttribute = keyof Pick<
-  INodeVisibility,
-  | 'nodeExists'
-  | 'isConnected'
-  | 'isOnscreenVertical'
-  | 'isOnscreenHorizontal'
-  | 'hasCssDisplay'
-  | 'hasCssVisibility'
-  | 'hasCssOpacity'
-  | 'hasDimensions'
-  | 'isUnobstructedByOtherElements'
->;

--- a/interfaces/IWaitForElementOptions.ts
+++ b/interfaces/IWaitForElementOptions.ts
@@ -1,8 +1,7 @@
 import IWaitForOptions from './IWaitForOptions';
-import { INodeVisibilityAttribute } from './INodeVisibility';
 
 export default interface IWaitForElementOptions extends IWaitForOptions {
   waitForVisible?: boolean;
+  waitForClickable?: boolean;
   waitForHidden?: boolean;
-  ignoreVisibilityAttributes?: INodeVisibilityAttribute[];
 }

--- a/plugins/default-human-emulator/test/emulator.test.ts
+++ b/plugins/default-human-emulator/test/emulator.test.ts
@@ -210,9 +210,9 @@ function createInteractHelper(extras: Partial<IInteractionsHelper>): IInteractio
     },
     scrollOffset: Promise.resolve({ x: 0, y: 0 }),
     logger: log,
-    createMouseupTrigger() {
+    createMousedownTrigger() {
       return Promise.resolve({
-        nodeVisibility: {},
+        nodeVisibility: { isVisible: true, isClickable: true },
         didTrigger: () => Promise.resolve({ didClickLocation: true } as any),
       });
     },


### PR DESCRIPTION
1. Interactions now confirm that the proper element is being clicked on mousedown and cancel the mouse event if it's not right. This allows us to try to move out of the way of animating elements
2. DomExtenders: $isClickable, $isVisible (removes $nodeVisibility)
3. In nodeVisibility, isVisible is now the result of all "visibility" properties, and isClickable is the clickable ones