### PR TITLE
feat: renamed resource outputs to getters: buffer, text, json

### DIFF
--- a/client/lib/DomExtender.ts
+++ b/client/lib/DomExtender.ts
@@ -44,6 +44,10 @@ interface IBaseExtendNodeList {
   $map<T = any>(
     iteratorFn: (node: ISuperNode, index: number) => Promise<T>
   ): Promise<T[]>;
+  $reduce<T = any>(
+    iteratorFn: (initial: T, node: ISuperNode) => Promise<T>,
+    initial: T,
+  ): Promise<T>;
 }
 
 declare module 'awaited-dom/base/interfaces/super' {
@@ -140,6 +144,13 @@ const NodeListExtensionFns = {
       newArray.push(newItem);
     }
     return newArray;
+  },
+  async $reduce<T = any>(iteratorFn: (initial: T, node: ISuperNode) => Promise<T>, initial: T): Promise<T> {
+    const nodes = await this;
+    for (const node of nodes) {
+      initial = await iteratorFn(initial, node);
+    }
+    return initial;
   }
 }
 

--- a/client/lib/Resource.ts
+++ b/client/lib/Resource.ts
@@ -29,7 +29,7 @@ const propertyKeys: (keyof Resource)[] = [
   'request',
   'response',
   'documentUrl',
-  'data',
+  'buffer',
   'json',
   'text',
 ];
@@ -59,18 +59,18 @@ export default class Resource {
     return getState(this).resource.isRedirect ?? false;
   }
 
-  public get data(): Promise<Buffer> {
+  public get buffer(): Promise<Buffer> {
     const id = getState(this).resource.id;
     const coreTab = getState(this).coreTab;
-    return coreTab.then(x => x.getResourceProperty<Buffer>(id, 'data'));
+    return coreTab.then(x => x.getResourceProperty<Buffer>(id, 'buffer'));
   }
 
-  public text(): Promise<string> {
-    return this.data.then(x => x.toString());
+  public get text(): Promise<string> {
+    return this.buffer.then(x => x.toString());
   }
 
-  public json(): Promise<any> {
-    return this.text().then(JSON.parse);
+  public get json(): Promise<any> {
+    return this.text.then(JSON.parse);
   }
 
   public [Util.inspect.custom](): any {

--- a/client/lib/ResourceResponse.ts
+++ b/client/lib/ResourceResponse.ts
@@ -22,7 +22,9 @@ const propertyKeys: (keyof ResourceResponse)[] = [
   'statusMessage',
   'browserLoadFailure',
   'browserServedFromCache',
-  'data',
+  'buffer',
+  'text',
+  'json',
 ];
 
 export default class ResourceResponse {
@@ -60,16 +62,16 @@ export default class ResourceResponse {
     return getResponseProperty(this, 'statusMessage');
   }
 
-  public get data(): Promise<Buffer> {
-    return getResponseProperty(this, 'data');
+  public get buffer(): Promise<Buffer> {
+    return getResponseProperty(this, 'buffer');
   }
 
-  public text(): Promise<string> {
-    return this.data.then(x => x?.toString());
+  public get text(): Promise<string> {
+    return this.buffer.then(x => x?.toString());
   }
 
-  public json(): Promise<any> {
-    return this.text().then(JSON.parse);
+  public get json(): Promise<any> {
+    return this.text.then(JSON.parse);
   }
 
   public [Util.inspect.custom](): any {
@@ -88,7 +90,7 @@ export function createResourceResponse(
 
 function getResponseProperty<T>(
   container: ResourceResponse,
-  name: keyof IResourceResponse | 'data',
+  name: keyof IResourceResponse | 'buffer',
 ): Promise<T> {
   const state = getState(container);
   const id = state.resourceId;

--- a/client/lib/WebsocketResource.ts
+++ b/client/lib/WebsocketResource.ts
@@ -63,15 +63,15 @@ export default class WebsocketResource extends AwaitedEventTarget<IEventType> {
     return getState(this).resource.isRedirect ?? false;
   }
 
-  public get data(): Promise<Buffer> {
+  public get buffer(): Promise<Buffer> {
     throw new Error(subscribeErrorMessage);
   }
 
-  public text(): Promise<string> {
+  public get text(): Promise<string> {
     throw new Error(subscribeErrorMessage);
   }
 
-  public json(): Promise<any> {
+  public get json(): Promise<any> {
     throw new Error(subscribeErrorMessage);
   }
 

--- a/core/lib/Tab.ts
+++ b/core/lib/Tab.ts
@@ -310,7 +310,7 @@ export default class Tab
     resourceId: number,
     propertyPath: string,
   ): Promise<T> {
-    if (propertyPath === 'data' || propertyPath === 'response.data') {
+    if (propertyPath === 'buffer' || propertyPath === 'response.buffer') {
       return (await this.session.db.resources.getResourceBodyById(resourceId, true)) as any;
     }
 

--- a/fullstack/test/basic.test.ts
+++ b/fullstack/test/basic.test.ts
@@ -122,7 +122,7 @@ describe('basic Full Client tests', () => {
     expect(await response.remoteAddress).toBeTruthy();
     expect(await response.statusCode).toBe(200);
     expect(await response.statusMessage).toBe('OK');
-    expect(await response.text()).toMatch('<h1>Example Domain</h1>');
+    expect(await response.text).toMatch('<h1>Example Domain</h1>');
   });
 
   it('can get and set cookies', async () => {


### PR DESCRIPTION
- resource.data is renamed to resource.buffer
- resource.text was converted from method to getter.
- resource.json was converted from method to getter.
- snuck in a new dom extender ;)