### PR TITLE
Update AwaitedDom forEach; waitForResource duplicates; waitForResource default sinceCommandId

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
     "@ulixee/commons": "1.5.9",
     "@ulixee/hero-interfaces": "1.5.4",
     "@ulixee/hero-plugin-utils": "1.5.4",
-    "awaited-dom": "1.3.0",
+    "awaited-dom": "1.3.1",
     "nanoid": "^3.1.30",
     "ws": "^7.4.6"
   },

--- a/client/test/waitForResource.test.ts
+++ b/client/test/waitForResource.test.ts
@@ -172,8 +172,10 @@ describe('waitForResource', () => {
 
     const hero = new Hero({ connectionToCore: new Piper() });
     Helpers.needsClosing.push(hero);
+    let calls = 0;
     const resources = await hero.waitForResource({
       filterFn(resource, done) {
+        calls += 1;
         if (resource.url === '/test5.js') {
           done();
         }
@@ -184,6 +186,7 @@ describe('waitForResource', () => {
       },
     });
     expect(resources).toHaveLength(4);
+    expect(calls).toBe(5);
 
     await hero.close();
   });

--- a/core/lib/GlobalPool.ts
+++ b/core/lib/GlobalPool.ts
@@ -16,7 +16,7 @@ import Core from '../index';
 import IPuppetContext from '@ulixee/hero-interfaces/IPuppetContext';
 
 const { log } = Log(module);
-const disableMitm = Boolean(JSON.parse(process.env.HERO_DISABLE_MITM ?? 'false'));
+export const disableMitm = Boolean(JSON.parse(process.env.HERO_DISABLE_MITM ?? 'false'));
 
 export default class GlobalPool {
   public static maxConcurrentClientCount = 10;

--- a/core/lib/Resources.ts
+++ b/core/lib/Resources.ts
@@ -91,6 +91,7 @@ export default class Resources {
 
   public async createNewResourceIfUnseen(
     tabId: number,
+    frameId: number,
     resourceRequest: IPuppetResourceRequest,
     getBody: () => Promise<Buffer>,
   ): Promise<IResourceMeta | null> {
@@ -121,6 +122,7 @@ export default class Resources {
         knownResource.response = resourceDetails.response;
       }
       knownResource.response.browserLoadedTime = resource.browserLoadedTime;
+      knownResource.frameId ??= frameId;
       this.model.updateReceivedTime(knownResource.id, resource.browserLoadedTime);
       return true;
     }

--- a/core/package.json
+++ b/core/package.json
@@ -25,7 +25,7 @@
     "@ulixee/hero-puppet": "1.5.4",
     "@ulixee/hero-timetravel": "1.5.4",
     "@types/ua-parser-js": "^0.7.35",
-    "awaited-dom": "1.3.0",
+    "awaited-dom": "1.3.1",
     "better-sqlite3": "^7.4.1",
     "moment": "^2.24.1",
     "tough-cookie": "^4.0.0",

--- a/fullstack/package.json
+++ b/fullstack/package.json
@@ -21,7 +21,7 @@
     "@ulixee/hero-testing": "1.5.4",
     "fpcollect": "^1.0.4",
     "fpscanner": "^0.1.5",
-    "awaited-dom": "^1.3.0",
+    "awaited-dom": "1.3.1",
     "ws": "^7.4.6"
   }
 }

--- a/interfaces/package.json
+++ b/interfaces/package.json
@@ -3,7 +3,7 @@
   "version": "1.5.4",
   "description": "Core interfaces used by Hero",
   "dependencies": {
-    "awaited-dom": "1.3.0",
+    "awaited-dom": "1.3.1",
     "@ulixee/commons": "1.5.9",
     "devtools-protocol": "^0.0.799653"
   }

--- a/mitm/lib/BrowserRequestMatcher.ts
+++ b/mitm/lib/BrowserRequestMatcher.ts
@@ -186,10 +186,12 @@ export default class BrowserRequestMatcher {
         id: pendingRequest.mitmResourceId,
       },
     };
-    pendingRequest.resolveTimeout = setTimeout(
-      () => this.logger.warn('BrowserRequestMatcher.ResourceNotResolved', toLog),
-      5e3,
-    ).unref();
+    pendingRequest.resolveTimeout = setTimeout(() => {
+      this.logger.warn('BrowserRequestMatcher.ResourceNotResolved', toLog);
+      pendingRequest.browserRequestedPromise.reject(
+        new Error('BrowserRequestMatcher.ResourceNotResolved'),
+      );
+    }, 5e3).unref();
     return pendingRequest;
   }
 

--- a/mitm/lib/SocketPool.ts
+++ b/mitm/lib/SocketPool.ts
@@ -67,7 +67,7 @@ export default class SocketPool {
       if (this.free.size) {
         const first = this.free.values().next().value;
         this.free.delete(first);
-        return first;
+        if (first) return first;
       }
 
       const mitmSocket = await createSocket();

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/node": "^13.13.52",
     "@typescript-eslint/eslint-plugin": "^5.1.0",
     "@typescript-eslint/parser": "^5.1.0",
-    "awaited-dom": "^1.3.0",
+    "awaited-dom": "^1.3.1",
     "copyfiles": "^2.4.1",
     "cross-env": "^7.0.3",
     "decamelize": "^4.0.0",

--- a/plugins/default-browser-emulator/lib/helpers/modifyHeaders.ts
+++ b/plugins/default-browser-emulator/lib/helpers/modifyHeaders.ts
@@ -96,7 +96,7 @@ function getResourceHeaderDefaults(
   headerProfiles: IDataHeaders,
   resource: IHttpResourceLoadDetails,
 ): Pick<IDataHeaderOrder, 'order' | 'orderKeys' | 'defaults'> {
-  const { method, originType, requestHeaders: headers, resourceType, isSSL } = resource;
+  const { method, originType, requestHeaders: headers, resourceType } = resource;
 
   let protocol = resource.isServerHttp2 ? 'http2' : 'https';
   if (!resource.isSSL) protocol = 'http';
@@ -130,14 +130,7 @@ function getResourceHeaderDefaults(
     }
   }
 
-  const defaultOrder = defaultOrders.length ? pickRandom(defaultOrders) : null;
-
-  if (!defaultOrder) {
-    browserEmulator.logger.info('Headers.NotFound', { resourceType, isSSL, method, originType });
-    return null;
-  }
-
-  return defaultOrder;
+  return defaultOrders.length ? pickRandom(defaultOrders) : null;
 }
 
 const lowerCaseMap = new Map<string, string>();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2307,10 +2307,10 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-awaited-dom@1.3.0, awaited-dom@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/awaited-dom/-/awaited-dom-1.3.0.tgz#90265018c2f8bb338e3ffd697c8f7d6a60e689c9"
-  integrity sha512-fQ3AgTqb6XdkVUyP/nHrrXUDoEOA/OhWzZIKxp5RvRwq3swm5vnWBAaIaQ4bh1mhIzzM+CTgUjyncePqX54zZQ==
+awaited-dom@1.3.1, awaited-dom@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/awaited-dom/-/awaited-dom-1.3.1.tgz#30d9daa86a85b7f55c96914d09f4ea4a257b958f"
+  integrity sha512-v6gwyQucUjfwyTHaYWTW3dt9X1aELcUMT8ov6m5pkWnadCmK4ZyfrfEtu67Tc4g6/8tG1UKBwnno5DVL6GURqg==
 
 aws-sign2@~0.7.0:
   version "0.7.0"


### PR DESCRIPTION
This PR includes 1 main change and 2 small updates.

1) waitForResource now defaults to looking since the last command. You can still override to use any since command if you want to go back earlier
2) waitForResource was returning duplicate resources because they were being double-recorded by the Man-in-the-middle and from puppet/devtools.
3) Update awaited dom version to 1.3.1
4) Fix the TimelineRecorder extending sessions too long