### PR TITLE
Experimental: Load Frozen Tabs from Db; Bug fixes

### DIFF
--- a/client/lib/CoreSession.ts
+++ b/client/lib/CoreSession.ts
@@ -141,6 +141,29 @@ export default class CoreSession implements IJsPathEventTarget {
     };
   }
 
+  // @experimental
+  public async loadFrozenTab(
+    sessionId: string,
+    name: string,
+    atCommandId: number,
+    tabId = 1,
+  ): Promise<{ coreTab: CoreTab; prefetchedJsPaths: IJsPathResult[] }> {
+    const { detachedTab, prefetchedJsPaths } = await this.commandQueue.runOutOfBand<{
+      detachedTab: ISessionMeta;
+      prefetchedJsPaths: IJsPathResult[];
+    }>('Session.loadFrozenTab', sessionId, name, atCommandId, tabId);
+    const coreTab = new CoreTab(
+      { ...detachedTab, sessionName: this.sessionName },
+      this.connectionToCore,
+      this,
+    );
+    this.frozenTabsById.set(detachedTab.tabId, coreTab);
+    return {
+      coreTab,
+      prefetchedJsPaths,
+    };
+  }
+
   public async close(force = false): Promise<void> {
     await this.shutdownPromise;
     if (this.isClosing) return;

--- a/client/lib/Hero.ts
+++ b/client/lib/Hero.ts
@@ -243,6 +243,21 @@ export default class Hero extends AwaitedEventTarget<{
     await tab.close();
   }
 
+  // @experimental
+  public loadFrozenTabs(
+    sessionId: string,
+    tabNameToCommandId: { [name: string]: number },
+  ): { [name: string]: FrozenTab } {
+    const coreSession = getState(this).connection.getConnectedCoreSessionOrReject();
+
+    const result: { [name: string]: FrozenTab } = {};
+    for (const [name, commandId] of Object.entries(tabNameToCommandId)) {
+      const coreFrozenTab = coreSession.then(x => x.loadFrozenTab(sessionId, name, commandId));
+      result[name] = new FrozenTab(this, coreFrozenTab);
+    }
+    return result;
+  }
+
   public detach(tab: Tab, key?: string): FrozenTab {
     const callSitePath = JSON.stringify(getCallSite(module.filename, scriptInstance.entrypoint));
 

--- a/core/dbs/SessionDb.ts
+++ b/core/dbs/SessionDb.ts
@@ -179,6 +179,7 @@ export default class SessionDb {
   }
 
   public static getCached(sessionId: string, fileMustExist = false): SessionDb {
+    if (sessionId.endsWith('.db')) sessionId = sessionId.split('.db').shift();
     if (!this.byId.get(sessionId)?.db?.open) {
       this.byId.set(
         sessionId,
@@ -193,6 +194,7 @@ export default class SessionDb {
 
   public static find(scriptArgs: ISessionFindArgs): ISessionFindResult {
     let { sessionId } = scriptArgs;
+    if (sessionId?.endsWith('.db')) sessionId = sessionId.split('.db').shift();
 
     // NOTE: don't close db - it's from a shared cache
     const sessionsDb = SessionsDb.find();

--- a/core/injected-scripts/pageEventsRecorder.ts
+++ b/core/injected-scripts/pageEventsRecorder.ts
@@ -625,11 +625,6 @@ class PageEventsRecorder {
     if (action === DomActionType.added) {
       this.nodeIdToParentNodeId[serial.id] = serial.parentNodeId;
 
-      // don't include this if it's hero id
-      if (this.doNotTrackElementsById.has(serial.id)) {
-        return;
-      }
-
       if (this.doNotTrackElementsById.has(serial.previousSiblingId)) {
         // get previous node that's tracked
         let previousNode: ChildNode = this.doNotTrackElementsById.get(serial.previousSiblingId);
@@ -640,6 +635,10 @@ class PageEventsRecorder {
         } while (previousNode && this.doNotTrackElementsById.has(nodeId));
         serial.previousSiblingId = nodeId;
       }
+    }
+    // don't include this if it's hero id
+    if (this.doNotTrackElementsById.has(serial.id)) {
+      return;
     }
     this.domChanges.push([action, serial, timestamp, idx()]);
   }

--- a/core/lib/Commands.ts
+++ b/core/lib/Commands.ts
@@ -51,7 +51,7 @@ export default class Commands {
     if (this.nextCommandMeta) {
       const { commandId, sendDate, startDate, callsite } = this.nextCommandMeta;
       this.nextCommandMeta = null;
-      commandMeta.id = commandId;
+      if (commandId) commandMeta.id = commandId;
       commandMeta.clientSendDate = sendDate?.getTime();
       commandMeta.clientStartDate = startDate?.getTime();
       commandMeta.callsite = callsite;

--- a/core/lib/FrameNavigationsObserver.ts
+++ b/core/lib/FrameNavigationsObserver.ts
@@ -286,7 +286,10 @@ export default class FrameNavigationsObserver {
       return existing.resolvable.promise;
     }
 
-    const resolvable = new Resolvable<INavigation>(timeoutMs ?? 60e3);
+    const resolvable = new Resolvable<INavigation>(
+      timeoutMs ?? 60e3,
+      `Timeout waiting for navigation "${status}"`,
+    );
     this.statusTriggers.push({
       status,
       startCommandId,

--- a/core/lib/Session.ts
+++ b/core/lib/Session.ts
@@ -37,6 +37,7 @@ import Commands from './Commands';
 import WebsocketMessages from './WebsocketMessages';
 import SessionsDb from '../dbs/SessionsDb';
 import { IRemoteEmitFn, IRemoteEventListener } from '../interfaces/IRemoteEventListener';
+import DetachedTabState from './DetachedTabState';
 
 const { log } = Log(module);
 
@@ -96,6 +97,7 @@ export default class Session
   public readonly db: SessionDb;
 
   public tabsById = new Map<number, Tab>();
+  public detachedTabsById = new Map<number, Tab>();
 
   public get isClosing(): boolean {
     return this._isClosing;
@@ -138,7 +140,6 @@ export default class Session
   private isolatedMitmProxy?: MitmProxy;
   private _isClosing = false;
   private isResettingState = false;
-  private detachedTabsById = new Map<number, Tab>();
   private readonly logSubscriptionId: number;
 
   constructor(readonly options: ISessionCreateOptions) {
@@ -263,27 +264,15 @@ export default class Session
 
     const detachedState = await sourceTab.createDetachedState(callsite, key);
 
-    const newTab = await detachedState.openInNewTab(this.browserContext, this.viewport);
-
-    this.recordTab(
-      newTab.id,
-      newTab.puppetPage.id,
-      newTab.puppetPage.devtoolsSession.id,
-      sourceTab.id,
-      detachedState.detachedAtCommandId,
+    const result = await detachedState.openInNewTab(
+      this.viewport,
+      `Frozen Tab at Command ${detachedState.detachedAtCommandId}`,
     );
-    this.detachedTabsById.set(newTab.id, newTab);
-    newTab.on('close', () => {
-      if (newTab.mainFrameEnvironment.jsPath.hasNewExecJsPathHistory) {
-        detachedState.saveHistory(newTab.mainFrameEnvironment.jsPath.execHistory);
-      }
 
-      this.detachedTabsById.delete(newTab.id);
-    });
+    this.recordTab(result.detachedTab, sourceTabId, detachedState.detachedAtCommandId);
+    this.registerDetachedTab(result.detachedTab);
 
-    const jsPathCalls = detachedState.getJsPathHistory();
-    const prefetches = await newTab.mainFrameEnvironment.prefetchExecJsPaths(jsPathCalls);
-    return { detachedTab: newTab, prefetchedJsPaths: prefetches };
+    return result;
   }
 
   public getMitmProxy(): { address: string; password?: string } {
@@ -349,8 +338,8 @@ export default class Session
 
     const first = this.tabsById.size === 0;
     const tab = Tab.create(this, page);
-    this.recordTab(tab.id, page.id, page.devtoolsSession.id);
-    this.registerTab(tab, page);
+    this.recordTab(tab);
+    this.registerTab(tab);
     await tab.isReady;
     if (first) this.db.session.updateConfiguration(this.id, this.meta);
     return tab;
@@ -583,12 +572,12 @@ export default class Session
     page: IPuppetPage,
     openParams: { url: string; windowName: string } | null,
   ): Promise<Tab> {
-    const tab = Tab.create(this, page, false, parentTab, {
+    const tab = Tab.create(this, page, false, parentTab?.id, {
       ...openParams,
       loaderId: page.mainFrame.isDefaultUrl ? null : page.mainFrame.activeLoader.id,
     });
-    this.recordTab(tab.id, page.id, page.devtoolsSession.id, parentTab.id);
-    this.registerTab(tab, page);
+    this.recordTab(tab, parentTab.id);
+    this.registerTab(tab);
 
     await tab.isReady;
 
@@ -596,7 +585,7 @@ export default class Session
     return tab;
   }
 
-  private registerTab(tab: Tab, page: IPuppetPage): Tab {
+  private registerTab(tab: Tab): Tab {
     const id = tab.id;
     this.tabsById.set(id, tab);
     tab.on('close', () => {
@@ -605,9 +594,15 @@ export default class Session
         this.emit('all-tabs-closed');
       }
     });
-    page.popupInitializeFn = this.onNewTab.bind(this, tab);
+    tab.puppetPage.popupInitializeFn = this.onNewTab.bind(this, tab);
     this.emit('tab-created', { tab });
     return tab;
+  }
+
+  private registerDetachedTab(tab: Tab): void {
+    const id = tab.id;
+    this.detachedTabsById.set(id, tab);
+    tab.once('close', () => this.detachedTabsById.delete(id));
   }
 
   private async newPage(): Promise<IPuppetPage> {
@@ -623,17 +618,11 @@ export default class Session
     }
   }
 
-  private recordTab(
-    tabId: number,
-    pageId: string,
-    devtoolsSessionId: string,
-    parentTabId?: number,
-    detachedAtCommandId?: number,
-  ): void {
+  private recordTab(tab: Tab, parentTabId?: number, detachedAtCommandId?: number): void {
     this.db.tabs.insert(
-      tabId,
-      pageId,
-      devtoolsSessionId,
+      tab.id,
+      tab.puppetPage.id,
+      tab.puppetPage.devtoolsSession.id,
       this.viewport,
       parentTabId,
       detachedAtCommandId,

--- a/core/lib/Tab.ts
+++ b/core/lib/Tab.ts
@@ -429,58 +429,36 @@ export default class Tab
   }
 
   public async goBack(options?: { timeoutMs?: number }): Promise<string> {
-    const navigation = this.navigations.onNavigationRequested(
-      'goBack',
-      null,
-      this.lastCommandId,
-      null,
-    );
-    const backUrl = await this.puppetPage.goBack();
-    this.navigations.assignLoaderId(navigation, this.puppetPage.mainFrame.activeLoader.id, backUrl);
-
+    this.navigations.initiatedUserAction = { reason: 'goBack', startCommandId: this.lastCommandId };
+    await this.puppetPage.goBack();
     await this.navigationsObserver.waitForLoad(LoadStatus.PaintingStable, options);
     return this.url;
   }
 
   public async goForward(options?: { timeoutMs?: number }): Promise<string> {
-    const navigation = this.navigations.onNavigationRequested(
-      'goForward',
-      null,
-      this.lastCommandId,
-      null,
-    );
-    const url = await this.puppetPage.goForward();
-    this.navigations.assignLoaderId(navigation, this.puppetPage.mainFrame.activeLoader.id, url);
+    this.navigations.initiatedUserAction = {
+      reason: 'goForward',
+      startCommandId: this.lastCommandId,
+    };
+    await this.puppetPage.goForward();
     await this.navigationsObserver.waitForLoad(LoadStatus.PaintingStable, options);
     return this.url;
   }
 
   public async reload(options?: { timeoutMs?: number }): Promise<IResourceMeta> {
-    const navigation = this.navigations.onNavigationRequested(
-      'reload',
-      this.url,
-      this.lastCommandId,
-      null,
-    );
+    this.navigations.initiatedUserAction = { reason: 'reload', startCommandId: this.lastCommandId };
 
     const timer = new Timer(options?.timeoutMs ?? 30e3, this.waitTimeouts);
     const timeoutMessage = `Timeout waiting for "tab.reload()"`;
 
-    let loaderId = this.puppetPage.mainFrame.activeLoader.id;
+    const loaderId = this.puppetPage.mainFrame.activeLoader.id;
     await timer.waitForPromise(this.puppetPage.reload(), timeoutMessage);
     if (this.puppetPage.mainFrame.activeLoader.id === loaderId) {
-      const frameNavigated = await timer.waitForPromise(
+      await timer.waitForPromise(
         this.puppetPage.mainFrame.waitOn('frame-navigated', null, options?.timeoutMs),
         timeoutMessage,
       );
-      loaderId = frameNavigated.loaderId;
     }
-
-    this.navigations.assignLoaderId(
-      navigation,
-      loaderId ?? this.puppetPage.mainFrame.activeLoader?.id,
-    );
-
     const resource = await timer.waitForPromise(
       this.navigationsObserver.waitForNavigationResourceId(),
       timeoutMessage,

--- a/core/lib/Tab.ts
+++ b/core/lib/Tab.ts
@@ -663,7 +663,17 @@ export default class Tab
           : [],
       domChanges: domChanges.length,
     });
-    return new DetachedTabState(this, lastLoadedNavigation, domChanges, callsite, key);
+    return new DetachedTabState(
+      this.session.db,
+      this.id,
+      new Set([lastLoadedNavigation.frameId]),
+      this.session,
+      this.session.commands.lastId,
+      lastLoadedNavigation,
+      domChanges,
+      callsite,
+      key,
+    );
   }
 
   /////// CLIENT EVENTS ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1104,12 +1114,12 @@ export default class Tab
     session: Session,
     puppetPage: IPuppetPage,
     isDetached?: boolean,
-    parentTab?: Tab,
+    parentTabId?: number,
     openParams?: { url: string; windowName: string; loaderId: string },
   ): Tab {
-    const tab = new Tab(session, puppetPage, isDetached, parentTab?.id, openParams);
+    const tab = new Tab(session, puppetPage, isDetached, parentTabId, openParams);
     tab.logger.info('Tab.created', {
-      parentTab: parentTab?.id,
+      parentTab: parentTabId,
       openParams,
     });
     return tab;

--- a/core/models/DevtoolsMessagesTable.ts
+++ b/core/models/DevtoolsMessagesTable.ts
@@ -107,6 +107,10 @@ export default class DevtoolsMessagesTable extends SqliteTable<IDevtoolsMessageR
         return `${value.substr(0, 50)}... [truncated ${value.length - 50} chars]`;
       }
 
+      if (key === 'body' && method === 'Fetch.fulfillRequest') {
+        return `${value.substr(0, 50)}... [truncated ${value.length - 50} chars]`;
+      }
+
       if ((key === 'headers' || key === 'postData') && params.request) {
         // clean out post data (we have these in resources table)
         return 'HERO_REMOVED_FOR_DB';

--- a/core/models/DomChangesTable.ts
+++ b/core/models/DomChangesTable.ts
@@ -72,12 +72,12 @@ export default class DomChangesTable extends SqliteTable<IDomChangeRecord> {
     return records;
   }
 
-  public getFrameChanges(frameId: number, sinceCommandId?: number): IDomChangeRecord[] {
+  public getFrameChanges(frameId: number, afterCommandId?: number): IDomChangeRecord[] {
     const query = this.db.prepare(
       `select * from ${this.tableName} where frameId =? and commandId > ?`,
     );
 
-    return query.all(frameId, sinceCommandId ?? 0).map(DomChangesTable.inflateRecord);
+    return query.all(frameId, afterCommandId ?? 0).map(DomChangesTable.inflateRecord);
   }
 
   public getChangesSinceNavigation(navigationId: number): IDomChangeRecord[] {

--- a/fullstack/test/tab.test.ts
+++ b/fullstack/test/tab.test.ts
@@ -155,6 +155,7 @@ describe('Multi-tab scenarios', () => {
     expect(await newTab.tabId).not.toBe(await hero.activeTab.tabId);
     expect(await newTab.url).toBe(`${koaServer.baseUrl}/newTab`);
     await hero.focusTab(newTab);
+    await newTab.waitForLoad('DomContentLoaded');
     const { document } = newTab;
     expect(await document.querySelector('#newTabHeader').textContent).toBe('You are here');
 

--- a/fullstack/test/websocket.test.ts
+++ b/fullstack/test/websocket.test.ts
@@ -6,7 +6,7 @@ import HttpUpgradeHandler from '@ulixee/hero-mitm/handlers/HttpUpgradeHandler';
 import WebsocketResource from '@ulixee/hero/lib/WebsocketResource';
 import { ITestKoaServer } from '@ulixee/hero-testing/helpers';
 import { AddressInfo } from 'net';
-import Hero, { Core } from "../index";
+import Hero, { Core } from '../index';
 
 let koaServer: ITestKoaServer;
 beforeAll(async () => {
@@ -50,12 +50,14 @@ describe('Websocket tests', () => {
   </body>
   <script>
     const ws = new WebSocket('ws://localhost:${(koaServer.server.address() as AddressInfo).port}');
+    let hasMessage = false;
     ws.onmessage = msg => {
+      hasMessage = true;
       ws.send('Echo ' + msg.data);
     };
     let hasRun = false;
     document.addEventListener('mousemove', () => {
-      if (hasRun) return;
+      if (hasRun || !hasMessage) return;
       hasRun = true;
       ws.send('Final message');
     })

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "json2md": "^1.7.0",
     "lerna": "^4.0.0",
     "lint-staged": "^10.5.2",
-    "noderdom-detached": "git://github.com/ulixee/noderdom-detached.git#dist",
+    "noderdom-detached": "https://github.com/ulixee/noderdom-detached.git#dist",
     "prettier": "^2.2.1",
     "pretty-quick": "^3.1.0",
     "shx": "^0.3.3",

--- a/puppet-chrome/lib/BrowserContext.ts
+++ b/puppet-chrome/lib/BrowserContext.ts
@@ -100,7 +100,7 @@ export class BrowserContext
     if (!page) {
       const pageAttachedPromise = new Resolvable<Page>(
         60e3,
-        'Error creating page. Timed out waiting to attach',
+        'Error creating page. Timed-out waiting to attach',
       );
       this.waitForPageAttachedById.set(targetId, pageAttachedPromise);
       page = await pageAttachedPromise.promise;

--- a/timetravel/injected-scripts/domReplayerUI.ts
+++ b/timetravel/injected-scripts/domReplayerUI.ts
@@ -4,13 +4,13 @@ import {} from '@ulixee/hero-interfaces/IDomChangeEvent';
 declare global {
   interface Window {
     showReplayStatus(text: string);
-    showReplayOverlay();
-    hideReplayOverlay();
+    overlay(options?: { notify?: string; hide?: boolean });
     reattachUI();
   }
 }
 
 let overlayNode: HTMLElement;
+let overlayNotification: HTMLElement;
 let overlayContainer: HTMLElement;
 let overlayShadow: ShadowRoot;
 
@@ -51,14 +51,18 @@ window.showReplayStatus = function showReplayStatus(text: string) {
   }
 };
 
-window.hideReplayOverlay = function hideReplayOverlay() {
-  overlayNode.classList.add('hide');
-};
-
-window.showReplayOverlay = function showReplayOverlay() {
+window.overlay = function overlay(options?: { hide?: boolean; notify?: string }) {
+  if (options?.hide === true) {
+    overlayNode.classList.add('hide');
+    return;
+  }
   if (overlayNode) {
     window.reattachUI();
     overlayNode.classList.remove('hide');
+    if (options?.notify) {
+      overlayNode.classList.add('notify');
+      overlayNotification.textContent = options.notify;
+    }
     return;
   }
 
@@ -67,6 +71,10 @@ window.showReplayOverlay = function showReplayOverlay() {
 
   overlayNode = document.createElement('hero-mask');
   overlayNode.textContent = ' ';
+
+  overlayNotification = document.createElement('hero-notification');
+  overlayNotification.textContent = ' ';
+  overlayNode.appendChild(overlayNotification);
 
   const spinner = document.createElement('hero-spinner');
   for (let i = 0; i < 12; i += 1) {
@@ -88,11 +96,39 @@ window.showReplayOverlay = function showReplayOverlay() {
     opacity: 1;
     z-index: 2147483647;
   }
+  
+  hero-mask.notify {
+    background-color: #eeeeee50;
+    pointer-events: none;
+    cursor: default;
+  }
+  
   hero-mask.hide {
     opacity: 0;
     transition-duration: 100ms;
     cursor: default;
     pointer-events: none;
+  }
+  
+  hero-mask hero-notification {
+    display:block;
+    font-size: 18px;
+    font-weight: bold;
+    text-align: center;
+    background: rgb(250, 244, 255);
+    width: 300px;
+    box-shadow: 3px 4px 5px #ddd;
+    margin: 15px auto;
+    pointer-events:auto;
+    border-radius: 10px;
+    height: 50px;
+    vertical-align: middle;
+    line-height: 50px;
+    border: 1px solid rgba(0, 0, 0, 0.3);
+  }
+  
+  hero-mask.notify hero-spinner {
+    display:none;
   }
 
   hero-spinner {

--- a/timetravel/player/TimetravelPlayer.ts
+++ b/timetravel/player/TimetravelPlayer.ts
@@ -70,7 +70,7 @@ export default class TimetravelPlayer extends TypedEventEmitter<{
   public async loadTick(tick: ITick): Promise<void> {
     await this.isReady;
     const tab = this.activeTab;
-    if (!tab.isOpen) await tab.open(this.loadIntoContext.browserContext);
+    await this.openTab(tab);
 
     await tab.loadTick(tick);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6142,9 +6142,9 @@ node-releases@^2.0.0:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.1.tgz#3d1d395f204f1f2f29a54358b9fb678765ad2fc5"
   integrity sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==
 
-"noderdom-detached@git://github.com/ulixee/noderdom-detached.git#dist":
+"noderdom-detached@https://github.com/ulixee/noderdom-detached.git#dist":
   version "0.3.2"
-  resolved "git://github.com/ulixee/noderdom-detached.git#25b6180898bec798a18b2821a4ce57896b688da9"
+  resolved "https://github.com/ulixee/noderdom-detached.git#25b6180898bec798a18b2821a4ce57896b688da9"
   dependencies:
     "@types/parse5" "^5.0.2"
     "@types/underscore" "^1.9.4"


### PR DESCRIPTION
1) Fix a bug that we were tracking removals of doNotTrack elements in timetravel
2) If you used "goBack" on a single page app, it could hang
3) Add an overlay to frozen tabs so you can see that they are frozen
4) Fix git:// paths in package.json to https. git: was deprecated

Experimental feature:
Ability to load frozen tabs from a session database - this enables you to separate the logic to extract data from a session from the interaction to create it.