### PR TITLE
feat(core): collect and recreate fragments

### DIFF
--- a/client/lib/CoreFrameEnvironment.ts
+++ b/client/lib/CoreFrameEnvironment.ts
@@ -82,6 +82,10 @@ export default class CoreFrameEnvironment {
     return await this.commandQueue.run('FrameEnvironment.createRequest', input, init);
   }
 
+  public async createFragment(name: string, jsPath: IJsPath): Promise<INodePointer> {
+    return await this.commandQueue.run('FrameEnvironment.createFragment', name, jsPath);
+  }
+
   public async getUrl(): Promise<string> {
     return await this.commandQueue.run('FrameEnvironment.getUrl');
   }

--- a/client/lib/Fragment.ts
+++ b/client/lib/Fragment.ts
@@ -1,0 +1,37 @@
+import AwaitedPath from 'awaited-dom/base/AwaitedPath';
+import { ISuperElement } from 'awaited-dom/base/interfaces/super';
+import FrozenTab from './FrozenTab';
+import { createInstanceWithNodePointer } from './SetupAwaitedHandler';
+import { getState as getFrozenFrameState } from './FrozenFrameEnvironment';
+import INodePointer from 'awaited-dom/base/INodePointer';
+import StateMachine from 'awaited-dom/base/StateMachine';
+import IAwaitedOptions from '../interfaces/IAwaitedOptions';
+
+const awaitedPathState = StateMachine<
+  any,
+  { awaitedPath: AwaitedPath; awaitedOptions: IAwaitedOptions; nodePointer?: INodePointer }
+>();
+
+export default class Fragment {
+  public element: ISuperElement;
+  public name: string;
+
+  readonly #nodePointer: INodePointer;
+  readonly #frozenTab: FrozenTab;
+
+  constructor(frozenTab: FrozenTab, name: string, nodePointer: INodePointer) {
+    this.name = name;
+    this.#frozenTab = frozenTab;
+    this.#nodePointer = nodePointer;
+    this.element = createInstanceWithNodePointer(
+      awaitedPathState,
+      new AwaitedPath(null),
+      getFrozenFrameState(frozenTab.mainFrameEnvironment),
+      nodePointer,
+    );
+  }
+
+  public close(): Promise<void> {
+    return this.#frozenTab.close();
+  }
+}

--- a/client/lib/FrozenFrameEnvironment.ts
+++ b/client/lib/FrozenFrameEnvironment.ts
@@ -29,7 +29,7 @@ import CoreFrameEnvironment from './CoreFrameEnvironment';
 import FrozenTab from './FrozenTab';
 import * as AwaitedHandler from './SetupAwaitedHandler';
 
-const { getState, setState } = StateMachine<FrozenFrameEnvironment, IState>();
+export const { getState, setState } = StateMachine<FrozenFrameEnvironment, IState>();
 const awaitedPathState = StateMachine<
   any,
   { awaitedPath: AwaitedPath; awaitedOptions: IAwaitedOptions }

--- a/core/dbs/SessionDb.ts
+++ b/core/dbs/SessionDb.ts
@@ -24,6 +24,7 @@ import SocketsTable from '../models/SocketsTable';
 import Core from '../index';
 import StorageChangesTable from '../models/StorageChangesTable';
 import AwaitedEventsTable from '../models/AwaitedEventsTable';
+import FragmentsTable from '../models/FragmentsTable';
 
 const { log } = Log(module);
 
@@ -48,6 +49,7 @@ export default class SessionDb {
   public readonly resourceStates: ResourceStatesTable;
   public readonly websocketMessages: WebsocketMessagesTable;
   public readonly domChanges: DomChangesTable;
+  public readonly fragments: FragmentsTable;
   public readonly pageLogs: PageLogsTable;
   public readonly sessionLogs: SessionLogsTable;
   public readonly session: SessionTable;
@@ -87,6 +89,7 @@ export default class SessionDb {
     this.resourceStates = new ResourceStatesTable(this.db);
     this.websocketMessages = new WebsocketMessagesTable(this.db);
     this.domChanges = new DomChangesTable(this.db);
+    this.fragments = new FragmentsTable(this.db);
     this.pageLogs = new PageLogsTable(this.db);
     this.session = new SessionTable(this.db);
     this.mouseEvents = new MouseEventsTable(this.db);
@@ -108,6 +111,7 @@ export default class SessionDb {
       this.resourceStates,
       this.websocketMessages,
       this.domChanges,
+      this.fragments,
       this.pageLogs,
       this.session,
       this.mouseEvents,

--- a/core/lib/DetachedTabState.ts
+++ b/core/lib/DetachedTabState.ts
@@ -14,6 +14,7 @@ import { IJsPathHistory } from './JsPath';
 import SessionDb from '../dbs/SessionDb';
 import IJsPathResult from '@ulixee/hero-interfaces/IJsPathResult';
 import { IPuppetPage } from '@ulixee/hero-interfaces/IPuppetPage';
+import IPuppetContext from '@ulixee/hero-interfaces/IPuppetContext';
 
 export default class DetachedTabState {
   public get url(): string {
@@ -52,7 +53,7 @@ export default class DetachedTabState {
     readonly detachedAtCommandId: number,
     private readonly initialPageNavigation: INavigation,
     domChangeRecords: IDomChangeRecord[],
-    readonly callsite: string,
+    readonly callsitePath: string,
     readonly key?: string,
   ) {
     this.mirrorNetwork = DetachedTabState.createMirrorNetwork(sourceTabId, sessionDb);
@@ -74,10 +75,11 @@ export default class DetachedTabState {
 
   public async openInNewTab(
     viewport: IViewport,
+    context?: IPuppetContext,
     label?: string,
   ): Promise<{ detachedTab: Tab; prefetchedJsPaths: IJsPathResult[] }> {
     await this.mirrorPage.open(
-      this.activeSession.browserContext,
+      context ?? this.activeSession.browserContext,
       this.sessionDb.sessionId,
       viewport,
       this.onNewPuppetPage.bind(this),
@@ -117,7 +119,11 @@ export default class DetachedTabState {
 
   public getJsPathHistory(): IJsPathHistory[] {
     const { scriptInstanceMeta } = this.activeSession.options;
-    return SessionsDb.find().findDetachedJsPathCalls(scriptInstanceMeta, this.callsite, this.key);
+    return SessionsDb.find().findDetachedJsPathCalls(
+      scriptInstanceMeta,
+      this.callsitePath,
+      this.key,
+    );
   }
 
   public saveHistory(history: IJsPathHistory[]): void {
@@ -125,7 +131,7 @@ export default class DetachedTabState {
     SessionsDb.find().recordDetachedJsPathCalls(
       scriptInstanceMeta,
       history,
-      this.callsite,
+      this.callsitePath,
       this.key,
     );
   }

--- a/core/lib/JsPath.ts
+++ b/core/lib/JsPath.ts
@@ -77,7 +77,13 @@ export class JsPath {
       }
     }
 
-    // add a node pointer call onto the end if needed
+    return this.getNodePointer(jsPath, containerOffset);
+  }
+
+  public getNodePointer<T>(
+    jsPath: IJsPath,
+    containerOffset: IPoint = { x: 0, y: 0 },
+  ): Promise<IExecJsPathResult<T>> {
     const fnCall = this.getJsPathMethod(jsPath);
     if (fnCall !== getClientRectFnName && fnCall !== getNodePointerFnName) {
       jsPath = [...jsPath, [getNodePointerFnName]];
@@ -161,6 +167,13 @@ export class JsPath {
       this.recordExecResult(jsPath, result, false);
     }
     return results;
+  }
+
+  public setFragmentNode(nodePointer: INodePointer): void {
+    this.nodeIdToHistoryLocation.set(nodePointer.id, { sourceIndex: 0, isFromIterable: false });
+    this.execHistory.push({
+      jsPath: [nodePointer.id, [getNodePointerFnName]],
+    });
   }
 
   private async runJsPath<T>(

--- a/core/lib/Tab.ts
+++ b/core/lib/Tab.ts
@@ -116,7 +116,6 @@ export default class Tab
     return this.frameEnvironmentsByPuppetId.get(this.puppetPage.mainFrame.id);
   }
 
-  // eslint-disable-next-line @typescript-eslint/member-ordering
   private constructor(
     session: Session,
     puppetPage: IPuppetPage,

--- a/core/models/DomChangesTable.ts
+++ b/core/models/DomChangesTable.ts
@@ -80,6 +80,17 @@ export default class DomChangesTable extends SqliteTable<IDomChangeRecord> {
     return query.all(frameId, afterCommandId ?? 0).map(DomChangesTable.inflateRecord);
   }
 
+  public getDomChangesForNavigation(
+    frameNavigationId: number,
+    upToEventIndex: number,
+  ): IDomChangeRecord[] {
+    const query = this.db.prepare(
+      `select * from ${this.tableName} where frameNavigationId =? and eventIndex <= ?`,
+    );
+
+    return query.all(frameNavigationId, upToEventIndex).map(DomChangesTable.inflateRecord);
+  }
+
   public getChangesSinceNavigation(navigationId: number): IDomChangeRecord[] {
     const query = this.db.prepare(`select * from ${this.tableName} where frameNavigationId >= ?`);
 

--- a/core/models/FragmentsTable.ts
+++ b/core/models/FragmentsTable.ts
@@ -1,0 +1,48 @@
+import { Database as SqliteDatabase } from 'better-sqlite3';
+import SqliteTable from '@ulixee/commons/lib/SqliteTable';
+
+export default class FragmentsTable extends SqliteTable<IFragment> {
+  private names = new Set<string>();
+  constructor(readonly db: SqliteDatabase) {
+    super(
+      db,
+      'Fragments',
+      [
+        ['name', 'TEXT', 'NOT NULL PRIMARY KEY'],
+        ['commandId', 'INTEGER'],
+        ['frameNavigationId', 'INTEGER'],
+        ['domChangeEventIndex', 'INTEGER'],
+        ['nodePointerId', 'INTEGER'],
+        ['nodeType', 'TEXT'],
+        ['nodePreview', 'TEXT'],
+      ],
+      true,
+    );
+  }
+
+  public insert(fragment: IFragment): void {
+    if (this.names.has(fragment.name))
+      throw new Error(
+        `The provided fragment name (${fragment.name}) must be unique for a session.`,
+      );
+    this.queuePendingInsert([
+      fragment.name,
+      fragment.commandId,
+      fragment.frameNavigationId,
+      fragment.domChangeEventIndex,
+      fragment.nodePointerId,
+      fragment.nodeType,
+      fragment.nodePreview,
+    ]);
+  }
+}
+
+export interface IFragment {
+  name: string;
+  commandId: number;
+  frameNavigationId: number;
+  domChangeEventIndex: number;
+  nodePointerId: number;
+  nodeType: string;
+  nodePreview: string;
+}

--- a/core/models/FrameNavigationsTable.ts
+++ b/core/models/FrameNavigationsTable.ts
@@ -46,6 +46,10 @@ export default class FrameNavigationsTable extends SqliteTable<IFrameNavigationR
     return [...this.allNavigationsById.values()];
   }
 
+  public get(id: number): INavigation {
+    return this.allNavigationsById.get(id) ?? FrameNavigationsTable.toNavigation(this.getById(id));
+  }
+
   public insert(navigation: INavigation): void {
     this.allNavigationsById.set(navigation.id, navigation);
     const record = [
@@ -74,6 +78,12 @@ export default class FrameNavigationsTable extends SqliteTable<IFrameNavigationR
     return this.db
       .prepare(`select * from ${this.tableName} order by initiatedTime desc limit 1`)
       .get() as IFrameNavigationRecord;
+  }
+
+  public getById(id: number): IFrameNavigationRecord {
+    return this.db
+      .prepare(`select * from ${this.tableName} where id=?`)
+      .get(id) as IFrameNavigationRecord;
   }
 
   public getMostRecentTabNavigations(

--- a/fullstack/test/fragments.test.ts
+++ b/fullstack/test/fragments.test.ts
@@ -1,0 +1,98 @@
+import { Helpers } from '@ulixee/hero-testing';
+import { ITestKoaServer } from '@ulixee/hero-testing/helpers';
+import Hero, { ConnectionToCore } from '../index';
+
+let koaServer: ITestKoaServer;
+const sendRequestSpy = jest.spyOn(ConnectionToCore.prototype, 'sendRequest');
+beforeAll(async () => {
+  koaServer = await Helpers.runKoaServer();
+});
+afterAll(Helpers.afterAll);
+afterEach(Helpers.afterEach);
+
+describe('basic Fragment tests', () => {
+  it('can create fragments', async () => {
+    koaServer.get('/fragment-basic', ctx => {
+      ctx.body = `
+        <body>
+          <div class="test1">test 1</div>
+          <div class="test2">
+            <ul><li>Test 2</li></ul>
+          </div>
+        </body>
+      `;
+    });
+    const hero = await openBrowser(`/fragment-basic`);
+    const test1Element = await hero.document.querySelector('.test1');
+    await test1Element.$extractLater('a');
+    await test1Element.nextElementSibling.$extractLater('b');
+
+    await hero.importFragments(await hero.sessionId);
+
+    expect(hero.getFragment('a')).toBeTruthy();
+    await expect(hero.getFragment('a').innerText).resolves.toBe('test 1');
+
+    expect(hero.getFragment('b')).toBeTruthy();
+    await expect(hero.getFragment('b').childElementCount).resolves.toBe(1);
+    await expect(hero.getFragment('b').querySelectorAll('li').length).resolves.toBe(1);
+  });
+
+  it('can prefetch fragment commands', async () => {
+    koaServer.get('/fragment-learn', ctx => {
+      ctx.body = `
+        <body>
+          <div class="test1">test 1</div>
+          <div class="test2" ready="true">test 2</div>
+        </body>
+      `;
+    });
+    {
+      // run 1
+      const hero = await openBrowser(`/fragment-learn`);
+      const test1Element = await hero.document.querySelector('.test1');
+      await test1Element.$extractLater('test1');
+      await test1Element.nextElementSibling.$extractLater('test2');
+
+      sendRequestSpy.mockClear();
+      await hero.importFragments(await hero.sessionId);
+
+      expect(hero.getFragment('test1')).toBeTruthy();
+      await expect(hero.getFragment('test1').innerText).resolves.toBe('test 1');
+      await expect(hero.getFragment('test1').hasAttribute('ready')).resolves.toBe(false);
+
+      expect(hero.getFragment('test2')).toBeTruthy();
+      await expect(hero.getFragment('test2').innerText).resolves.toBe('test 2');
+      await expect(hero.getFragment('test2').hasAttribute('ready')).resolves.toBe(true);
+      expect(sendRequestSpy).toHaveBeenCalledTimes(5);
+      // need to close to record jspaths
+      await hero.close();
+    }
+    {
+      // run 1
+      const hero = await openBrowser(`/fragment-learn`);
+      const test1Element = await hero.document.querySelector('.test1');
+      await test1Element.$extractLater('test1');
+      await test1Element.nextElementSibling.$extractLater('test2');
+
+      sendRequestSpy.mockClear();
+      await hero.importFragments(await hero.sessionId);
+
+      expect(hero.getFragment('test1')).toBeTruthy();
+      await expect(hero.getFragment('test1').innerText).resolves.toBe('test 1');
+      await expect(hero.getFragment('test1').hasAttribute('ready')).resolves.toBe(false);
+
+      expect(hero.getFragment('test2')).toBeTruthy();
+      await expect(hero.getFragment('test2').innerText).resolves.toBe('test 2');
+      await expect(hero.getFragment('test2').hasAttribute('ready')).resolves.toBe(true);
+      expect(sendRequestSpy).toHaveBeenCalledTimes(1);
+    }
+  });
+});
+
+async function openBrowser(path: string) {
+  const hero = new Hero();
+  Helpers.needsClosing.push(hero);
+  await hero.goto(`${koaServer.baseUrl}${path}`);
+  await hero.waitForPaintingStable();
+  return hero;
+}


### PR DESCRIPTION
This PR adds an ability to save "fragments" in the dom that are static snapshots which can later be retrieved.

Dom nodes are saved with a name using $extractLater. They can be retrieved by importing all dom fragments and then calling getFragment(name).

Heroboxes will automatically retrieve all dom fragments