### PR TITLE
Timeline <-> dom misaligned

### DIFF
--- a/core/injected-scripts/pageEventsRecorder.ts
+++ b/core/injected-scripts/pageEventsRecorder.ts
@@ -295,6 +295,7 @@ class PageEventsRecorder {
       this.location = currentLocation;
       const timestamp = changeUnixTime || Date.now();
       this.pushChange(DomActionType.location, { id: -1, textContent: currentLocation }, timestamp);
+      this.trackScroll(window.scrollX, window.scrollY);
     }
   }
 

--- a/core/lib/FrameEnvironment.ts
+++ b/core/lib/FrameEnvironment.ts
@@ -630,15 +630,25 @@ b) Use the UserProfile feature to set cookies for 1 or more domains before they'
       lastCommand = commands.getCommandForTimestamp(lastCommand, timestamp);
       if (timestamp > this.lastDomChangeTimestamp) this.lastDomChangeTimestamp = timestamp;
 
-      if (action === DomActionType.newDocument) {
+      if (action === DomActionType.newDocument || action === DomActionType.location) {
         const url = domChange[1].textContent;
         documentNavigation = this.navigations.findHistory(x => x.finalUrl === url);
 
-        if (
-          documentNavigation &&
-          documentNavigation.id > (this.lastDomChangeDocumentNavigationId ?? 0)
-        ) {
-          this.lastDomChangeDocumentNavigationId = documentNavigation.id;
+        if (documentNavigation) {
+          if (action === DomActionType.location && documentNavigation.initiatedTime < timestamp) {
+            documentNavigation.initiatedTime = timestamp;
+            // if we already have dom content loaded, update to the new timestamp
+            if (documentNavigation.statusChanges.has('DomContentLoaded')) {
+              documentNavigation.statusChanges.set('DomContentLoaded', timestamp);
+              documentNavigation.statusChanges.set('AllContentLoaded', timestamp);
+            }
+          }
+          if (
+            action === DomActionType.newDocument &&
+            documentNavigation.id > (this.lastDomChangeDocumentNavigationId ?? 0)
+          ) {
+            this.lastDomChangeDocumentNavigationId = documentNavigation.id;
+          }
         }
       }
 

--- a/core/lib/InjectedScripts.ts
+++ b/core/lib/InjectedScripts.ts
@@ -83,12 +83,14 @@ export default class InjectedScripts {
     ]);
   }
 
-  public static installInteractionScript(puppetPage: IPuppetPage): Promise<void> {
+  public static installInteractionScript(puppetPage: IPuppetPage): Promise<{ identifier: string }> {
     return puppetPage.addNewDocumentScript(showInteractionScript, true);
   }
 
-  public static async installDomStorageRestore(puppetPage: IPuppetPage): Promise<void> {
-    await puppetPage.addNewDocumentScript(
+  public static async installDomStorageRestore(
+    puppetPage: IPuppetPage,
+  ): Promise<{ identifier: string }> {
+    return await puppetPage.addNewDocumentScript(
       `(function restoreDomStorage() {
 const exports = {}; // workaround for ts adding an exports variable
 ${stringifiedTypeSerializerClass};

--- a/core/lib/Session.ts
+++ b/core/lib/Session.ts
@@ -532,10 +532,11 @@ export default class Session
     const result = { didKeepAlive: false, message: null };
     result.message = `This session has the "sessionKeepAlive" variable active. Your Chrome session will remain open until you terminate this Hero instance.`;
     result.didKeepAlive = true;
-    this.emit('kept-alive', result);
     for (const tab of this.tabsById.values()) {
       await tab.flushDomChanges();
     }
+    // run after command completes
+    setImmediate(() => this.emit('kept-alive', result));
     return result;
   }
 

--- a/core/models/FrameNavigationsTable.ts
+++ b/core/models/FrameNavigationsTable.ts
@@ -106,14 +106,16 @@ export default class FrameNavigationsTable extends SqliteTable<IFrameNavigationR
     recreateResolvable = false,
   ): INavigation {
     const entry = record as any as INavigation;
-    entry.statusChanges = new Map<NavigationStatus, number>([
+    const entries = [
       [LoadStatus.HttpRequested, record.httpRequestedTime],
       [LoadStatus.HttpResponded, record.httpRespondedTime],
       [LoadStatus.HttpRedirected, record.httpRedirectedTime],
       [LoadStatus.DomContentLoaded, record.domContentLoadedTime],
       [LoadStatus.AllContentLoaded, record.loadTime],
-      [LoadStatus.PaintingStable, record.contentPaintedTime],
-    ]);
+      [ContentPaint, record.contentPaintedTime],
+    ].filter(x => !!x[1]);
+
+    entry.statusChanges = new Map<NavigationStatus, number>(entries as any);
     if (recreateResolvable) {
       entry.resourceIdResolvable = new Resolvable();
       if (entry.resourceId) entry.resourceIdResolvable.resolve(entry.resourceId);

--- a/interfaces/IDomChangeEvent.ts
+++ b/interfaces/IDomChangeEvent.ts
@@ -32,6 +32,7 @@ export interface IFrontendDomChangeEvent extends Omit<INodeData, 'id'> {
   nodeId: number;
   eventIndex: number;
   action: DomActionType;
+  previousLocation?: string;
   previousPreviousSiblingId?: number;
   previousParentNodeId?: number;
   previousTextContent?: string;

--- a/interfaces/IPuppetContext.ts
+++ b/interfaces/IPuppetContext.ts
@@ -30,6 +30,7 @@ export default interface IPuppetContext extends ITypedEventEmitter<IPuppetContex
 
 export interface IPuppetPageOptions {
   runPageScripts: boolean;
+  enableDomStorageTracker?: boolean;
   triggerPopupOnPageId?: string;
 }
 

--- a/interfaces/IPuppetPage.ts
+++ b/interfaces/IPuppetPage.ts
@@ -50,7 +50,11 @@ export interface IPuppetPage extends ITypedEventEmitter<IPuppetPageEvents> {
   setJavaScriptEnabled(enabled: boolean): Promise<void>;
 
   evaluate<T>(expression: string): Promise<T>;
-  addNewDocumentScript(script: string, isolateFromWebPageEnvironment: boolean): Promise<void>;
+  addNewDocumentScript(
+    script: string,
+    isolateFromWebPageEnvironment: boolean,
+  ): Promise<{ identifier: string }>;
+  removeDocumentScript(identifier: string): Promise<void>;
   addPageCallback(
     name: string,
     onCallback?: (payload: any, frameId: string) => any,

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@commitlint/config-conventional": "^12.0.1",
     "@types/jest": "^26.0.20",
     "@types/node": "^13.13.52",
-    "@typescript-eslint/eslint-plugin": "^5.1.0",
+    "@typescript-eslint/eslint-plugin": "^5.10.1",
     "@typescript-eslint/parser": "^5.1.0",
     "awaited-dom": "^1.3.1",
     "copyfiles": "^2.4.1",

--- a/puppet-chrome/lib/BrowserContext.ts
+++ b/puppet-chrome/lib/BrowserContext.ts
@@ -1,9 +1,16 @@
 import { assert } from '@ulixee/commons/lib/utils';
-import IPuppetContext, { IPuppetContextEvents, IPuppetPageOptions } from '@ulixee/hero-interfaces/IPuppetContext';
+import IPuppetContext, {
+  IPuppetContextEvents,
+  IPuppetPageOptions,
+} from '@ulixee/hero-interfaces/IPuppetContext';
 import { ICookie } from '@ulixee/hero-interfaces/ICookie';
 import { URL } from 'url';
 import Protocol from 'devtools-protocol';
-import { addTypedEventListener, removeEventListeners, TypedEventEmitter } from '@ulixee/commons/lib/eventUtils';
+import {
+  addTypedEventListener,
+  removeEventListeners,
+  TypedEventEmitter,
+} from '@ulixee/commons/lib/eventUtils';
 import { IBoundLog } from '@ulixee/commons/interfaces/ILog';
 import IRegisteredEventListener from '@ulixee/commons/interfaces/IRegisteredEventListener';
 import { CanceledPromiseError } from '@ulixee/commons/interfaces/IPendingWaitEvent';
@@ -13,7 +20,10 @@ import ICorePlugins from '@ulixee/hero-interfaces/ICorePlugins';
 import { IPuppetPage } from '@ulixee/hero-interfaces/IPuppetPage';
 import IProxyConnectionOptions from '@ulixee/hero-interfaces/IProxyConnectionOptions';
 import Resolvable from '@ulixee/commons/lib/Resolvable';
-import { IDevtoolsEventMessage, IDevtoolsResponseMessage } from '@ulixee/hero-interfaces/IDevtoolsSession';
+import {
+  IDevtoolsEventMessage,
+  IDevtoolsResponseMessage,
+} from '@ulixee/hero-interfaces/IDevtoolsSession';
 import { Page } from './Page';
 import { Browser } from './Browser';
 import { DevtoolsSession } from './DevtoolsSession';
@@ -143,7 +153,14 @@ export class BrowserContext
       opener = this.pagesById.values().next().value;
     }
 
-    const page = new Page(devtoolsSession, targetInfo.targetId, this, this.logger, opener);
+    const page = new Page(
+      devtoolsSession,
+      targetInfo.targetId,
+      this,
+      this.logger,
+      opener,
+      pageOptions,
+    );
     this.pagesById.set(page.targetId, page);
     this.waitForPageAttachedById.get(page.targetId)?.resolve(page);
     await page.isReady;

--- a/puppet-chrome/lib/DomStorageTracker.ts
+++ b/puppet-chrome/lib/DomStorageTracker.ts
@@ -41,14 +41,17 @@ export class DomStorageTracker
   private readonly indexedDBContentUpdatingOrigins = new Set<string>();
 
   private trackedOrigins = new Set<string>();
+  private isEnabled = false;
 
   constructor(
     page: Page,
     storageByOrigin: IDomStorage,
     networkManager: NetworkManager,
     logger: IBoundLog,
+    isEnabled: boolean,
   ) {
     super();
+    this.isEnabled = isEnabled;
     this.page = page;
     this.devtoolsSession = page.devtoolsSession;
     this.networkManager = networkManager;
@@ -79,6 +82,7 @@ export class DomStorageTracker
   }
 
   public initialize(): Promise<void> {
+    if (!this.isEnabled) return Promise.resolve();
     return Promise.all([
       this.devtoolsSession.send('DOMStorage.enable'),
       this.devtoolsSession.send('IndexedDB.enable'),

--- a/puppet-chrome/lib/FramesManager.ts
+++ b/puppet-chrome/lib/FramesManager.ts
@@ -147,17 +147,24 @@ export default class FramesManager extends TypedEventEmitter<IPuppetFrameManager
     );
   }
 
-  public async addNewDocumentScript(script: string, installInIsolatedScope = true): Promise<void> {
-    await this.devtoolsSession.send('Page.addScriptToEvaluateOnNewDocument', {
-      source: script,
-      worldName: installInIsolatedScope ? ISOLATED_WORLD : undefined,
-    });
+  public async addNewDocumentScript(
+    script: string,
+    installInIsolatedScope = true,
+  ): Promise<{ identifier: string }> {
+    const installedScript = await this.devtoolsSession.send(
+      'Page.addScriptToEvaluateOnNewDocument',
+      {
+        source: script,
+        worldName: installInIsolatedScope ? ISOLATED_WORLD : undefined,
+      },
+    );
 
     // sometimes we get a new anchor link that already has an initiated frame. If that's the case, newDocumentScripts won't trigger.
     // NOTE: we DON'T want this to trigger for internal pages (':', 'about:blank')
     if (this.main.url?.startsWith('http')) {
       await this.main.evaluate(script, installInIsolatedScope, { retriesWaitingForLoad: 1 });
     }
+    return installedScript;
   }
 
   /////// EXECUTION CONTEXT ////////////////////////////////////////////////////

--- a/puppet-chrome/lib/Page.ts
+++ b/puppet-chrome/lib/Page.ts
@@ -44,6 +44,7 @@ import Size = Protocol.SystemInfo.Size;
 import Rect = Protocol.DOM.Rect;
 import SetDeviceMetricsOverrideRequest = Protocol.Emulation.SetDeviceMetricsOverrideRequest;
 import Viewport = Protocol.Page.Viewport;
+import { IPuppetPageOptions } from '@ulixee/hero-interfaces/IPuppetContext';
 
 export class Page extends TypedEventEmitter<IPuppetPageEvents> implements IPuppetPage {
   public keyboard: Keyboard;
@@ -94,6 +95,7 @@ export class Page extends TypedEventEmitter<IPuppetPageEvents> implements IPuppe
     browserContext: BrowserContext,
     logger: IBoundLog,
     opener: Page | null,
+    pageOptions?: IPuppetPageOptions,
   ) {
     super();
 
@@ -117,6 +119,7 @@ export class Page extends TypedEventEmitter<IPuppetPageEvents> implements IPuppe
       browserContext.domStorage,
       this.networkManager,
       this.logger,
+      pageOptions?.enableDomStorageTracker ?? true,
     );
     this.framesManager = new FramesManager(
       devtoolsSession,
@@ -175,8 +178,15 @@ export class Page extends TypedEventEmitter<IPuppetPageEvents> implements IPuppe
     return await this.networkManager.setNetworkInterceptor(networkRequestsFn, true);
   }
 
-  addNewDocumentScript(script: string, isolatedEnvironment: boolean): Promise<void> {
+  addNewDocumentScript(
+    script: string,
+    isolatedEnvironment: boolean,
+  ): Promise<{ identifier: string }> {
     return this.framesManager.addNewDocumentScript(script, isolatedEnvironment);
+  }
+
+  removeDocumentScript(identifier: string): Promise<void> {
+    return this.devtoolsSession.send('Page.removeScriptToEvaluateOnNewDocument', { identifier });
   }
 
   addPageCallback(

--- a/timetravel/injected-scripts/DomActions.ts
+++ b/timetravel/injected-scripts/DomActions.ts
@@ -28,7 +28,7 @@ class DomActions {
   public static replayDomEvent(event: IFrontendDomChangeEvent, isReverse = false): void {
     let { action } = event;
     if (action === DomActionType.newDocument) return this.onNewDocument(event);
-    if (action === DomActionType.location) return this.onLocation(event);
+    if (action === DomActionType.location) return this.onLocation(event, isReverse);
 
     if (isReverse) {
       if (action === DomActionType.added) action = DomActionType.removed;
@@ -223,9 +223,13 @@ class DomActions {
     window.scrollTo({ top: 0 });
   }
 
-  private static onLocation(event: IFrontendDomChangeEvent) {
+  private static onLocation(event: IFrontendDomChangeEvent, usePrevious = false) {
     debugLog('Location: href=%s', event.textContent);
-    window.history.replaceState({}, 'TimeTravel', event.textContent);
+    if (!usePrevious) {
+      event.previousLocation = window.location.href;
+    }
+    const url = usePrevious ? event.previousLocation : event.textContent;
+    window.history.replaceState({}, 'TimeTravel', url);
   }
 
   private static setNodeAttributes(

--- a/timetravel/lib/CommandTimeline.ts
+++ b/timetravel/lib/CommandTimeline.ts
@@ -47,6 +47,7 @@ export default class CommandTimeline<T extends ICommandMeta = ICommandMeta> {
       : this.firstCompletedNavigation?.statusChanges.get(LoadStatus.HttpRequested);
     const timelineEnd = timelineSubslice ? timelineSubslice[1] : null;
 
+    let isClosed = false;
     for (let i = 0; i < commandsFromAllRuns.length; i += 1) {
       const command = { ...commandsFromAllRuns[i] } as T & ICommandTimelineOffset;
       command.commandGapMs = 0;
@@ -112,7 +113,9 @@ export default class CommandTimeline<T extends ICommandMeta = ICommandMeta> {
         this.addNavigation(command.startNavigationId);
         this.addNavigation(command.endNavigationId);
         this.commands.push(command);
+        if (command.name === 'close') isClosed = true;
       }
+      if (isClosed) break;
     }
 
     if (timelineEnd && this.endTime < timelineEnd) {
@@ -129,7 +132,7 @@ export default class CommandTimeline<T extends ICommandMeta = ICommandMeta> {
   }
 
   public getTimelineOffsetForTimestamp(timestamp: number): number {
-    if (!timestamp) return -1;
+    if (!timestamp || timestamp > this.endTime) return -1;
 
     for (const command of this.commands) {
       if (
@@ -161,9 +164,9 @@ export default class CommandTimeline<T extends ICommandMeta = ICommandMeta> {
           relativeStartMs: x.relativeStartMs,
           commandGapMs: x.commandGapMs,
           runtimeMs: x.runtimeMs,
-        }
-      })
-    }
+        };
+      }),
+    };
   }
 
   private getTimelineOffsetForRuntimeMillis(timelineOffsetMs: number): number {

--- a/timetravel/lib/MirrorPage.ts
+++ b/timetravel/lib/MirrorPage.ts
@@ -66,7 +66,7 @@ export default class MirrorPage extends TypedEventEmitter<{
     const ready = new Resolvable<void>();
     this.isReady = ready.promise;
     try {
-      this.page = await context.newPage({ runPageScripts: false });
+      this.page = await context.newPage({ runPageScripts: false, enableDomStorageTracker: false });
       this.page.once('close', this.close.bind(this));
       if (this.debugLogging) {
         this.page.on('console', msg => {

--- a/timetravel/lib/MirrorPage.ts
+++ b/timetravel/lib/MirrorPage.ts
@@ -36,6 +36,7 @@ export default class MirrorPage extends TypedEventEmitter<{
     return this.page?.id;
   }
 
+  private domRecording: IDomRecording;
   private sessionId: string;
   private pendingDomChanges: IDomChangeRecord[] = [];
   private loadedDocument: IDocument;
@@ -46,11 +47,12 @@ export default class MirrorPage extends TypedEventEmitter<{
 
   constructor(
     public network: MirrorNetwork,
-    public domRecording: IDomRecording,
+    domRecording: IDomRecording,
     private showBrowserInteractions = false,
     private debugLogging = true,
   ) {
     super();
+    this.setDomRecording(domRecording);
     this.onPageEvents = this.onPageEvents.bind(this);
   }
 
@@ -109,11 +111,7 @@ export default class MirrorPage extends TypedEventEmitter<{
   }
 
   public async replaceDomRecording(domRecording: IDomRecording): Promise<void> {
-    this.domRecording = domRecording;
-    this.paintEventByTimestamp = {};
-    for (const paint of this.domRecording.paintEvents) {
-      this.paintEventByTimestamp[paint.timestamp] = paint;
-    }
+    this.setDomRecording(domRecording);
     if (this.loadedDocument) {
       this.isLoadedDocumentDirty = true;
       await this.injectPaintEvents(this.loadedDocument);
@@ -148,27 +146,13 @@ export default class MirrorPage extends TypedEventEmitter<{
       this.processPendingDomChanges();
       newPaintIndex ??= this.domRecording.paintEvents.length - 1;
 
-      let activeDocumentTimestamp = Date.now();
-      if (newPaintIndex < 0) {
-        if (this.domRecording.documents.length) {
-          activeDocumentTimestamp = this.domRecording.documents[0]?.paintStartTimestamp;
-        }
-      } else {
-        activeDocumentTimestamp = this.domRecording.paintEvents[newPaintIndex].timestamp;
-      }
-      let loadingDocument: IDocument;
-      for (const document of this.domRecording.documents) {
-        if (!document.isMainframe) continue;
-        if (document.paintStartTimestamp <= activeDocumentTimestamp) {
-          loadingDocument = document;
-        }
-        this.network.registerDoctype(document.url, document.doctype);
-      }
-
-      const page = this.page;
+      const loadingDocument = this.getActiveDocument(newPaintIndex);
 
       let isLoadingDocument = false;
-      if (loadingDocument && (loadingDocument.url !== page.mainFrame.url || newPaintIndex === -1)) {
+      if (
+        loadingDocument &&
+        (loadingDocument.url !== this.page.mainFrame.url || newPaintIndex === -1)
+      ) {
         isLoadingDocument = true;
 
         if (this.debugLogging) {
@@ -181,7 +165,7 @@ export default class MirrorPage extends TypedEventEmitter<{
         const loader = await this.page.navigate(loadingDocument.url);
 
         this.emit('goto', { url: loadingDocument.url, loaderId: loader.loaderId });
-        await page.mainFrame.waitForLifecycleEvent('DOMContentLoaded', loader.loaderId);
+        await this.page.mainFrame.waitForLifecycleEvent('DOMContentLoaded', loader.loaderId);
         this.loadedDocument = loadingDocument;
         this.isLoadedDocumentDirty = true;
       }
@@ -297,6 +281,36 @@ export default class MirrorPage extends TypedEventEmitter<{
     }
   }
 
+  private getActiveDocument(newPaintIndex: number): IDocument {
+    let activeDocumentTimestamp = Date.now();
+    if (newPaintIndex < 0) {
+      if (this.domRecording.documents.length) {
+        activeDocumentTimestamp = this.domRecording.documents[0]?.paintStartTimestamp;
+      }
+    } else {
+      activeDocumentTimestamp = this.domRecording.paintEvents[newPaintIndex].timestamp;
+    }
+    let loadingDocument: IDocument;
+    for (const document of this.domRecording.documents) {
+      if (!document.isMainframe) continue;
+      if (document.paintStartTimestamp <= activeDocumentTimestamp) {
+        loadingDocument = document;
+      }
+    }
+    return loadingDocument;
+  }
+
+  private setDomRecording(domRecording: IDomRecording): void {
+    this.domRecording = domRecording;
+    this.paintEventByTimestamp = {};
+    for (const paint of this.domRecording.paintEvents) {
+      this.paintEventByTimestamp[paint.timestamp] = paint;
+    }
+    for (const document of this.domRecording.documents) {
+      this.network.registerDoctype(document.url, document.doctype);
+    }
+  }
+
   private processPendingDomChanges(): void {
     if (!this.pendingDomChanges.length) return;
 
@@ -315,24 +329,19 @@ export default class MirrorPage extends TypedEventEmitter<{
       : null;
 
     let needsPaintSort = false;
+    const lastPaint = this.domRecording.paintEvents[this.domRecording.paintEvents.length - 1];
     for (const paint of domRecording.paintEvents) {
       const existing = this.paintEventByTimestamp[paint.timestamp];
 
       if (this.loadedDocument && paint.timestamp > this.loadedDocument.paintStartTimestamp) {
-        if (!nextDocument) {
-          this.isLoadedDocumentDirty = true;
-        } else if (paint.timestamp < nextDocument.paintStartTimestamp) {
+        if (!nextDocument || paint.timestamp < nextDocument.paintStartTimestamp) {
           this.isLoadedDocumentDirty = true;
         }
       }
 
       if (!existing) {
-        if (
-          paint.timestamp <
-          this.domRecording.paintEvents[this.domRecording.paintEvents.length - 1]?.timestamp
-        ) {
-          needsPaintSort = true;
-        }
+        needsPaintSort ||= paint.timestamp < lastPaint?.timestamp;
+
         this.domRecording.paintEvents.push(paint);
         this.paintEventByTimestamp[paint.timestamp] = paint;
       } else {
@@ -352,6 +361,7 @@ export default class MirrorPage extends TypedEventEmitter<{
         this.paintEventByTimestamp[document.paintStartTimestamp],
       );
       this.domRecording.documents.push(document);
+      this.network.registerDoctype(document.url, document.doctype);
     }
   }
 
@@ -443,6 +453,8 @@ export default class MirrorPage extends TypedEventEmitter<{
       `(function replayEvents(){
     const exports = {};
     window.isMainFrame = true;
+    window.selfFrameIdPath = 'main';
+    window.showMouseInteractions = true;
 
     const records = ${JSON.stringify(events).replace(/,null/g, ',')};
     const tagNamesById = ${JSON.stringify(tagNamesById)};

--- a/timetravel/lib/TimelineRecorder.ts
+++ b/timetravel/lib/TimelineRecorder.ts
@@ -33,10 +33,11 @@ export default class TimelineRecorder extends TypedEventEmitter<{
 
   public stop(): void {
     if (!this.heroSession) return;
+    this.heroSession.db.screenshots.unsubscribe();
     this.heroSession.off('tab-created', this.onTabCreated);
     this.heroSession.off('kept-alive', this.onHeroSessionPaused);
     this.heroSession.off('resumed', this.onHeroSessionResumed);
-    this.heroSession.on('will-close', this.onHeroSessionWillClose);
+    this.heroSession.off('will-close', this.onHeroSessionWillClose);
     this.stopRecording();
     this.dontExtendSessionPastTime();
   }

--- a/timetravel/player/TimetravelPlayer.ts
+++ b/timetravel/player/TimetravelPlayer.ts
@@ -178,7 +178,9 @@ export default class TimetravelPlayer extends TypedEventEmitter<{
   ): Promise<void> {
     if (this.timelineRange && this.timelineRange.toString() === timelineOffsetRange.toString())
       return;
-    this.timelineRange = [...timelineOffsetRange];
+    if (timelineOffsetRange) {
+      this.timelineRange = [...timelineOffsetRange];
+    }
     await this.load();
   }
 

--- a/timetravel/test/mirrorPage.test.ts
+++ b/timetravel/test/mirrorPage.test.ts
@@ -80,6 +80,7 @@ describe('MirrorPage tests', () => {
       const sourceHtmlNext = await tab.puppetPage.mainFrame.html();
       htmlAtSteps.push({
         html: sourceHtmlNext,
+        // @ts-ignore
         index: mirrorPage.domRecording.paintEvents.length - 1,
       });
       const mirrorHtmlNext = await mirrorPage.getHtml();


### PR DESCRIPTION
Very small changes to fix misalignment between the "timeline" bar.

Along the way, fixed a few issues:
- disable storage tracking in mirror pages (can throw off cookies)
- mouse not tracking on timetravel
- backwards "location" changes weren't working
- fix restoring the navigations from db when creating a timeline for the mirrorpage (this was the main issue)
- 