### PR TITLE
findResources; Merge waitForElement with waitForState; Initiate "flow" on failed waitForState

### DIFF
--- a/client/interfaces/IFlowHandler.ts
+++ b/client/interfaces/IFlowHandler.ts
@@ -6,5 +6,5 @@ export default interface IFlowHandler {
   id?: number;
   state: IDomState | DomState;
   handlerFn: (error?: Error) => Promise<any>;
-  callSitePath: ISourceCodeLocation[];
+  callsitePath: ISourceCodeLocation[];
 }

--- a/client/interfaces/IInteractions.ts
+++ b/client/interfaces/IInteractions.ts
@@ -3,7 +3,7 @@ import {
   IElementInteractVerification,
   IMousePositionXY,
 } from '@ulixee/hero-interfaces/IInteractions';
-import { ISuperElement, ISuperNode } from 'awaited-dom/base/interfaces/super';
+import { ISuperElement } from 'awaited-dom/base/interfaces/super';
 
 export type IInteraction = ICommand | ICommandDetailed;
 type IInteractions = IInteraction[];
@@ -39,8 +39,6 @@ export enum Command {
   keyUp = 'keyUp',
   type = 'type',
 
-  waitForNode = 'waitForNode',
-  waitForElementVisible = 'waitForElementVisible',
   waitForMillis = 'waitForMillis',
 }
 
@@ -71,8 +69,6 @@ export interface ICommandDetailed {
   [Command.keyUp]?: IKeyboardKeyCode;
   [Command.keyDown]?: IKeyboardKeyCode;
 
-  [Command.waitForNode]?: ISuperNode;
-  [Command.waitForElementVisible]?: ISuperElement;
   [Command.waitForMillis]?: number;
 }
 

--- a/client/lib/CoreCommandQueue.ts
+++ b/client/lib/CoreCommandQueue.ts
@@ -148,6 +148,7 @@ export default class CoreCommandQueue {
       args,
       commandId: this.nextCommandId,
       startDate: new Date(),
+      callsite: this.getCallsite(),
     });
   }
 
@@ -164,10 +165,6 @@ export default class CoreCommandQueue {
       }
     }
 
-    let callsite: string;
-    if (this.mode !== 'production') {
-      callsite = JSON.stringify(scriptInstance.getScriptCallSite());
-    }
     if (this.internalState.interceptFn) {
       const result = this.internalState.interceptFn(this.meta, command, ...args);
       if (result && result instanceof Error) {
@@ -176,7 +173,7 @@ export default class CoreCommandQueue {
       }
       return Promise.resolve(result as T);
     }
-
+    const callsite = this.getCallsite();
     const commandId = this.nextCommandId;
 
     const commandPayload = {
@@ -231,6 +228,12 @@ export default class CoreCommandQueue {
       this.commandCounter,
       this.internalState,
     );
+  }
+
+  private getCallsite(): string {
+    if (this.mode !== 'production') {
+      return JSON.stringify(scriptInstance.getScriptCallsite());
+    }
   }
 
   private async sendRequest<T>(

--- a/client/lib/CoreSession.ts
+++ b/client/lib/CoreSession.ts
@@ -133,13 +133,13 @@ export default class CoreSession implements IJsPathEventTarget {
 
   public async detachTab(
     tab: CoreTab,
-    callSitePath: string,
+    callsitePath: string,
     key?: string,
   ): Promise<{ coreTab: CoreTab; prefetchedJsPaths: IJsPathResult[] }> {
     const { detachedTab, prefetchedJsPaths } = await this.commandQueue.run<{
       detachedTab: ISessionMeta;
       prefetchedJsPaths: IJsPathResult[];
-    }>('Session.detachTab', tab.tabId, callSitePath, key);
+    }>('Session.detachTab', tab.tabId, callsitePath, key);
     const coreTab = new CoreTab(
       { ...detachedTab, sessionName: this.sessionName },
       this.connectionToCore,

--- a/client/lib/CoreTab.ts
+++ b/client/lib/CoreTab.ts
@@ -24,6 +24,7 @@ import { CanceledPromiseError } from '@ulixee/commons/interfaces/IPendingWaitEve
 import DomState from './DomState';
 import ISourceCodeLocation from '@ulixee/commons/interfaces/ISourceCodeLocation';
 import IDomState from '@ulixee/hero-interfaces/IDomState';
+import IResourceFilterProperties from '@ulixee/hero-interfaces/IResourceFilterProperties';
 
 export default class CoreTab implements IJsPathEventTarget {
   public tabId: number;
@@ -169,6 +170,13 @@ export default class CoreTab implements IJsPathEventTarget {
 
   public async goForward(options: { timeoutMs?: number }): Promise<string> {
     return await this.commandQueue.run('Tab.goForward', options);
+  }
+
+  public async findResource(
+    filter: IResourceFilterProperties,
+    options?: { sinceCommandId?: number },
+  ): Promise<IResourceMeta> {
+    return await this.commandQueue.run('Tab.findResource', filter, options);
   }
 
   public async reload(options: { timeoutMs?: number }): Promise<IResourceMeta> {

--- a/client/lib/FrameEnvironment.ts
+++ b/client/lib/FrameEnvironment.ts
@@ -33,7 +33,7 @@ import IAwaitedOptions from '../interfaces/IAwaitedOptions';
 import RequestGenerator, { getRequestIdOrUrl } from './Request';
 import CookieStorage, { createCookieStorage } from './CookieStorage';
 import Hero from './Hero';
-import { createInstanceWithNodePointer, getAwaitedPathAsMethodArg } from './SetupAwaitedHandler';
+import { getAwaitedPathAsMethodArg } from './SetupAwaitedHandler';
 import CoreFrameEnvironment from './CoreFrameEnvironment';
 import Tab, { getCoreTab } from './Tab';
 import Resource, { createResource } from './Resource';
@@ -233,17 +233,8 @@ export default class FrameEnvironment {
     element: ISuperElement,
     options?: IWaitForElementOptions,
   ): Promise<ISuperElement | null> {
-    if (!element) throw new Error('Element being waited for is null');
-    const { awaitedPath, awaitedOptions } = awaitedPathState.getState(element);
     const coreFrame = await this.#coreFramePromise;
-    const nodePointer = await coreFrame.waitForElement(awaitedPath.toJSON(), options);
-    if (!nodePointer) return null;
-    return createInstanceWithNodePointer(
-      awaitedPathState,
-      awaitedPath,
-      awaitedOptions,
-      nodePointer,
-    );
+    return await coreFrame.waitForElement(element, options);
   }
 
   public async waitForLocation(

--- a/client/lib/Hero.ts
+++ b/client/lib/Hero.ts
@@ -298,13 +298,13 @@ export default class Hero extends AwaitedEventTarget<{
   }
 
   public detach(tab: Tab, key?: string): FrozenTab {
-    const callSitePath = JSON.stringify(getCallSite(module.filename, scriptInstance.entrypoint));
+    const callsitePath = JSON.stringify(getCallSite(module.filename, scriptInstance.entrypoint));
 
     const coreTab = getCoreTab(tab);
     const coreSession = this.#getCoreSessionOrReject();
 
     const detachedTab = coreSession.then(async session =>
-      session.detachTab(await coreTab, callSitePath, key),
+      session.detachTab(await coreTab, callsitePath, key),
     );
 
     return new FrozenTab(this, detachedTab);

--- a/client/lib/Hero.ts
+++ b/client/lib/Hero.ts
@@ -64,6 +64,7 @@ import DomState from './DomState';
 import ConnectionToCore from '../connections/ConnectionToCore';
 import CoreSession from './CoreSession';
 import InternalProperties from './InternalProperties';
+import IResourceFilterProperties from '@ulixee/hero-interfaces/IResourceFilterProperties';
 
 export const DefaultOptions = {
   defaultBlockedResourceTypes: [BlockedResourceType.None],
@@ -250,6 +251,13 @@ export default class Hero extends AwaitedEventTarget<{
     }
     const coreTab = await getCoreTab(tab);
     await coreTab.close();
+  }
+
+  public async findResource(
+    filter: IResourceFilterProperties,
+    options?: { sinceCommandId: number },
+  ): Promise<Resource> {
+    return await this.activeTab.findResource(filter, options);
   }
 
   public async getCollectedResources(

--- a/client/lib/Interactor.ts
+++ b/client/lib/Interactor.ts
@@ -26,8 +26,6 @@ import { isAwaitedNode } from './SetupAwaitedHandler';
 const { getState } = StateMachine<ISuperElement | ISuperNode, { awaitedPath: AwaitedPath }>();
 
 const COMMAND_POS: { [k: string]: number } = {
-  waitForNode: 0,
-  waitForElementVisible: 1,
   waitForMillis: 2,
   click: 3,
   doubleclick: 4,
@@ -217,18 +215,6 @@ function convertInteractionToInteractionGroup(interaction: IInteraction): IInter
         return iGroup.push({ command, keyboardCommands });
       }
 
-      case Command.waitForNode: {
-        const command = CoreCommand.waitForNode;
-        const { awaitedPath } = getState(value);
-        const jsPath = awaitedPath.toJSON();
-        return iGroup.push({ command, delayNode: jsPath });
-      }
-      case Command.waitForElementVisible: {
-        const command = CoreCommand.waitForElementVisible;
-        const { awaitedPath } = getState(value);
-        const jsPath = awaitedPath.toJSON();
-        return iGroup.push({ command, delayElement: jsPath });
-      }
       case Command.waitForMillis: {
         const command = CoreCommand.waitForMillis;
         return iGroup.push({ command, delayMillis: value });

--- a/client/lib/Resource.ts
+++ b/client/lib/Resource.ts
@@ -11,6 +11,7 @@ import ResourceResponse, { createResourceResponse } from './ResourceResponse';
 import { createWebsocketResource } from './WebsocketResource';
 import IWaitForResourceFilter from '../interfaces/IWaitForResourceFilter';
 import Tab, { getCoreTab } from './Tab';
+import IResourceFilterProperties from '@ulixee/hero-interfaces/IResourceFilterProperties';
 
 const propertyKeys: (keyof Resource)[] = [
   'url',
@@ -73,6 +74,19 @@ export default class Resource {
 
   public [Util.inspect.custom](): any {
     return inspectInstanceProperties(this, propertyKeys as any);
+  }
+
+  public static async findLatest(
+    tab: Tab,
+    filter: IResourceFilterProperties,
+    options: { sinceCommandId: number },
+  ): Promise<Resource> {
+    const coreTab = await getCoreTab(tab);
+    const resourceMeta = await coreTab.findResource(filter, options);
+    if (resourceMeta) {
+      return createResource(Promise.resolve(coreTab), resourceMeta);
+    }
+    return null;
   }
 
   public static async waitFor(

--- a/client/lib/ScriptInstance.ts
+++ b/client/lib/ScriptInstance.ts
@@ -51,14 +51,14 @@ export default class ScriptInstance {
     return name;
   }
 
-  public getScriptCallSite(getCallSiteRegardlessOfMode = false): ISourceCodeLocation[] {
+  public getScriptCallsite(getCallSiteRegardlessOfMode = false): ISourceCodeLocation[] {
     if (!getCallSiteRegardlessOfMode && this.mode === 'production') return;
     const stack = getCallSite(module.filename);
 
     let stackLines: ISourceCodeLocation[] = [];
     let lastIndexOfEntrypoint = -1;
-    for (const callSite of stack) {
-      const { filename } = callSite;
+    for (const callsite of stack) {
+      const { filename } = callsite;
       if (!filename) continue;
 
       if (
@@ -71,7 +71,7 @@ export default class ScriptInstance {
         lastIndexOfEntrypoint = stackLines.length;
       }
 
-      stackLines.push(callSite);
+      stackLines.push(callsite);
     }
 
     if (lastIndexOfEntrypoint >= 0) stackLines = stackLines.slice(0, lastIndexOfEntrypoint + 1);

--- a/client/lib/Tab.ts
+++ b/client/lib/Tab.ts
@@ -21,6 +21,7 @@ import {
 import IScreenshotOptions from '@ulixee/hero-interfaces/IScreenshotOptions';
 import AwaitedPath from 'awaited-dom/base/AwaitedPath';
 import { INodeVisibility } from '@ulixee/hero-interfaces/INodeVisibility';
+import IResourceFilterProperties from '@ulixee/hero-interfaces/IResourceFilterProperties';
 import * as Util from 'util';
 import CoreTab from './CoreTab';
 import Resource, { createResource } from './Resource';
@@ -149,6 +150,13 @@ export default class Tab extends AwaitedEventTarget<IEventType> {
   }
 
   // METHODS
+
+  public findResource(
+    filter: IResourceFilterProperties,
+    options?: { sinceCommandId: number },
+  ): Promise<Resource> {
+    return Resource.findLatest(this, filter, options);
+  }
 
   public async fetch(request: Request | string, init?: IRequestInit): Promise<Response> {
     return await this.mainFrameEnvironment.fetch(request, init);

--- a/client/lib/Tab.ts
+++ b/client/lib/Tab.ts
@@ -35,7 +35,6 @@ import CoreFrameEnvironment from './CoreFrameEnvironment';
 import IAwaitedOptions from '../interfaces/IAwaitedOptions';
 import Dialog from './Dialog';
 import FileChooser from './FileChooser';
-import DomStateHandler from './DomStateHandler';
 import DomState from './DomState';
 import IDomState from '@ulixee/hero-interfaces/IDomState';
 import InternalProperties from './InternalProperties';
@@ -245,29 +244,24 @@ export default class Tab extends AwaitedEventTarget<IEventType> {
     state: IDomState | DomState,
     options: Pick<IWaitForOptions, 'timeoutMs'> = { timeoutMs: 30e3 },
   ): Promise<void> {
-    const callSitePath = scriptInstance.getScriptCallSite();
-
     const coreTab = await this.#coreTabPromise;
-    const handler = new DomStateHandler(state, coreTab, callSitePath);
-    await handler.waitFor(options.timeoutMs);
+    return coreTab.waitForState(state, options);
   }
 
   public async checkState(state: IDomState | DomState): Promise<boolean> {
-    const callSitePath = scriptInstance.getScriptCallSite();
-
+    const callsitePath = scriptInstance.getScriptCallsite();
     const coreTab = await this.#coreTabPromise;
-    const handler = new DomStateHandler(state, coreTab, callSitePath);
-    return await handler.check();
+    return coreTab.checkState(state, callsitePath);
   }
 
   public async registerFlowHandler(
     state: IDomState | DomState,
     handlerFn: (error?: Error) => Promise<any>,
   ): Promise<void> {
-    const callSitePath = scriptInstance.getScriptCallSite();
+    const callsitePath = scriptInstance.getScriptCallsite();
 
     const coreTab = await this.#coreTabPromise;
-    await coreTab.registerFlowHandler(state, handlerFn, callSitePath);
+    await coreTab.registerFlowHandler(state, handlerFn, callsitePath);
   }
 
   public async checkFlowHandlers(): Promise<void> {
@@ -285,7 +279,7 @@ export default class Tab extends AwaitedEventTarget<IEventType> {
   public async waitForElement(
     element: ISuperElement,
     options?: IWaitForElementOptions,
-  ): Promise<ISuperElement | null> {
+  ): Promise<ISuperElement> {
     return await this.mainFrameEnvironment.waitForElement(element, options);
   }
 

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
     "@ulixee/commons": "1.5.9",
     "@ulixee/hero-interfaces": "1.5.4",
     "@ulixee/hero-plugin-utils": "1.5.4",
-    "awaited-dom": "1.3.1",
+    "awaited-dom": "1.3.2",
     "nanoid": "^3.1.30",
     "ws": "^7.4.6"
   },

--- a/client/test/basic.test.ts
+++ b/client/test/basic.test.ts
@@ -95,10 +95,10 @@ describe('basic Hero tests', () => {
 
 describe('ScriptInstance tests', () => {
   it('should be able to properly get a script location', () => {
-    expect(scriptInstance.getScriptCallSite()).toHaveLength(1);
+    expect(scriptInstance.getScriptCallsite()).toHaveLength(1);
 
     (function testNested() {
-      expect(scriptInstance.getScriptCallSite()).toHaveLength(2);
+      expect(scriptInstance.getScriptCallsite()).toHaveLength(2);
     })();
   });
 });

--- a/core/injected-scripts/jsPath.ts
+++ b/core/injected-scripts/jsPath.ts
@@ -165,61 +165,6 @@ class JsPath {
     }
     return results;
   }
-
-  public static async waitForElement(
-    jsPath: IJsPath,
-    containerOffset: IPoint,
-    options: {
-      waitForVisible: boolean;
-      waitForHidden: boolean;
-      waitForClickable: boolean;
-    },
-    timeoutMillis: number,
-  ): Promise<IExecJsPathResult<INodeVisibility>> {
-    const objectAtPath = new ObjectAtPath(jsPath, containerOffset);
-    const { waitForVisible, waitForHidden, waitForClickable } = options;
-    try {
-      const end = new Date();
-      end.setTime(end.getTime() + (timeoutMillis || 0));
-
-      while (new Date() < end) {
-        try {
-          if (!objectAtPath.objectAtPath) objectAtPath.lookup();
-
-          const visibility = objectAtPath.getComputedVisibility();
-
-          let isElementValid = visibility.nodeExists;
-          if (waitForVisible) {
-            isElementValid = visibility.isVisible === true;
-          } else if (waitForHidden) {
-            isElementValid = visibility.isVisible === false;
-          } else if (waitForClickable) {
-            isElementValid = visibility.isClickable === true;
-          }
-
-          if (isElementValid) {
-            return {
-              nodePointer: objectAtPath.extractNodePointer(),
-              value: visibility,
-            };
-          }
-        } catch (err) {
-          if (String(err).includes('not a valid selector')) throw err;
-          // can also happen if lookup path doesn't exist yet... in which case we want to keep trying
-        }
-        // eslint-disable-next-line promise/param-names
-        await new Promise(resolve1 => setTimeout(resolve1, 20));
-        await new Promise(requestAnimationFrame);
-      }
-
-      return {
-        nodePointer: objectAtPath.extractNodePointer(),
-        value: objectAtPath.getComputedVisibility(),
-      };
-    } catch (error) {
-      return objectAtPath.toReturnError(error);
-    }
-  }
 }
 
 // / Object At Path Class //////

--- a/core/lib/Interactor.ts
+++ b/core/lib/Interactor.ts
@@ -339,14 +339,6 @@ export default class Interactor implements IInteractionsHelper {
         break;
       }
 
-      case InteractionCommand.waitForNode: {
-        await this.frameEnvironment.waitForDom(interaction.delayNode);
-        break;
-      }
-      case InteractionCommand.waitForElementVisible: {
-        await this.frameEnvironment.waitForDom(interaction.delayElement, { waitForVisible: true });
-        break;
-      }
       case InteractionCommand.waitForMillis: {
         await waitFor(interaction.delayMillis, resolvable);
         break;

--- a/core/lib/JsPath.ts
+++ b/core/lib/JsPath.ts
@@ -60,9 +60,9 @@ export class JsPath {
     if (typeof jsPath[0] === 'number') {
       const paths = this.getJsPathHistoryForNode(jsPath[0]);
       for (const path of paths) {
-        const result = await this.runJsPath<any>('exec', path.jsPath, containerOffset);
+        const result = await this.getNodePointer(path.jsPath, containerOffset);
         const nodeId = result.nodePointer?.id;
-        if (nodeId !== path.nodeId) {
+        if (nodeId && nodeId !== path.nodeId) {
           this.logger.info('JsPath.nodeRedirectFound', {
             sourceNodeId: path.nodeId,
             newNodeId: nodeId,

--- a/core/lib/JsPath.ts
+++ b/core/lib/JsPath.ts
@@ -18,7 +18,6 @@ import {
   getNodePointerFnName,
 } from '@ulixee/hero-interfaces/jsPathFnNames';
 import IElementRect from '@ulixee/hero-interfaces/IElementRect';
-import IWaitForElementOptions from '@ulixee/hero-interfaces/IWaitForElementOptions';
 
 const { log } = Log(module);
 
@@ -97,21 +96,6 @@ export class JsPath {
       }
       jsPath[0] = id;
     }
-  }
-
-  public waitForElement(
-    jsPath: IJsPath,
-    containerOffset: IPoint,
-    options: IWaitForElementOptions,
-    timeoutMillis: number,
-  ): Promise<IExecJsPathResult<INodeVisibility>> {
-    return this.runJsPath<INodeVisibility>(
-      `waitForElement`,
-      jsPath,
-      containerOffset,
-      options as any,
-      timeoutMillis,
-    );
   }
 
   public simulateOptionClick(jsPath: IJsPath): Promise<IExecJsPathResult<boolean>> {

--- a/core/lib/Tab.ts
+++ b/core/lib/Tab.ts
@@ -27,11 +27,11 @@ import Resolvable from '@ulixee/commons/lib/Resolvable';
 import { INodePointer } from '@ulixee/hero-interfaces/AwaitedDom';
 import INavigation from '@ulixee/hero-interfaces/INavigation';
 import injectedSourceUrl from '@ulixee/hero-interfaces/injectedSourceUrl';
+import IResourceFilterProperties from '@ulixee/hero-interfaces/IResourceFilterProperties';
 import IDomStateListenArgs from '@ulixee/hero-interfaces/IDomStateListenArgs';
 import FrameNavigations from './FrameNavigations';
 import CommandRecorder from './CommandRecorder';
 import FrameEnvironment from './FrameEnvironment';
-import IResourceFilterProperties from '../interfaces/IResourceFilterProperties';
 import InjectedScripts from './InjectedScripts';
 import Session from './Session';
 import FrameNavigationsObserver from './FrameNavigationsObserver';
@@ -182,6 +182,7 @@ export default class Tab
     this.commandRecorder = new CommandRecorder(this, this.session, this.id, this.mainFrameId, [
       this.focus,
       this.dismissDialog,
+      this.findResource,
       this.getFrameEnvironments,
       this.goto,
       this.goBack,
@@ -370,17 +371,23 @@ export default class Tab
     }
   }
 
-  public findResource(filter: IResourceFilterProperties): IResourceMeta {
+  public findResource(
+    filter: IResourceFilterProperties,
+    options?: { sinceCommandId: number },
+  ): Promise<IResourceMeta> {
     // escape query string ? so it can run as regex
     if (typeof filter.url === 'string') {
       filter.url = stringToRegex(filter.url);
     }
-    for (const resourceMeta of this.session.resources.getForTab(this.id)) {
-      if (this.isResourceFilterMatch(resourceMeta, filter)) {
-        return resourceMeta;
+    const sinceCommandId =
+      options?.sinceCommandId ?? this.navigations.lastHttpNavigationRequest?.startCommandId;
+    // find latest resource
+    for (const resourceMeta of this.session.resources.getForTab(this.id).reverse()) {
+      if (this.isResourceFilterMatch(resourceMeta, filter, sinceCommandId)) {
+        return Promise.resolve(resourceMeta);
       }
     }
-    return null;
+    return Promise.resolve(null);
   }
 
   public findStorageChange(

--- a/core/models/ResourcesTable.ts
+++ b/core/models/ResourcesTable.ts
@@ -363,9 +363,9 @@ from ${this.tableName} where ${useResourceBody}`,
 
   public static toResourceSummary(record: IResourcesRecord): IResourceSummary {
     const headers =
-      typeof record.responseHeaders === 'string'
+      (typeof record.responseHeaders === 'string'
         ? JSON.parse(record.responseHeaders ?? '{}')
-        : record.responseHeaders;
+        : record.responseHeaders) ?? {};
 
     return {
       id: record.id,

--- a/core/package.json
+++ b/core/package.json
@@ -25,7 +25,7 @@
     "@ulixee/hero-puppet": "1.5.4",
     "@ulixee/hero-timetravel": "1.5.4",
     "@types/ua-parser-js": "^0.7.35",
-    "awaited-dom": "1.3.1",
+    "awaited-dom": "1.3.2",
     "better-sqlite3": "^7.4.1",
     "moment": "^2.24.1",
     "tough-cookie": "^4.0.0",

--- a/core/test/apis.test.ts
+++ b/core/test/apis.test.ts
@@ -43,7 +43,10 @@ describe('basic Apis tests', () => {
     await tab.goto(`${koaServer.baseUrl}/api-test`);
     await tab.waitForLoad('DomContentLoaded');
     await tab.interact([{ command: 'click', mousePosition: ['document', ['querySelector', 'a']] }]);
-    await tab.waitForElement(['document', ['querySelector', 'a#link2']]);
+    await Helpers.waitForElement(
+      ['document', ['querySelector', 'a#link2']],
+      tab.mainFrameEnvironment,
+    );
     await tab.session.close();
     await Core.shutdown();
   });
@@ -88,8 +91,8 @@ describe('basic Apis tests', () => {
       args: { sessionId },
     });
     expect(result.tabDetails).toHaveLength(1);
-    expect(result.tabDetails[0].ticks.length).toBeGreaterThanOrEqual(5);
-    expect(result.tabDetails[0].ticks.filter(x => x.isMajor)).toHaveLength(5);
+    expect(result.tabDetails[0].ticks.length).toBeGreaterThanOrEqual(4);
+    expect(result.tabDetails[0].ticks.filter(x => x.isMajor)).toHaveLength(4);
     expect(result.tabDetails[0].ticks.filter(x => x.isNewDocumentTick)).toHaveLength(1);
     // only should be returned if asked for
     expect(result.tabDetails[0].mouse).not.toBeTruthy();
@@ -109,7 +112,7 @@ describe('basic Apis tests', () => {
     });
     expect(result.tabDetails).toHaveLength(1);
     expect(result.tabDetails[0].paintEvents.length).toBeGreaterThanOrEqual(1);
-    expect(result.tabDetails[0].commands).toHaveLength(5);
+    expect(result.tabDetails[0].commands).toHaveLength(4);
     expect(result.tabDetails[0].mouse.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/core/test/domRecorder.test.ts
+++ b/core/test/domRecorder.test.ts
@@ -53,8 +53,10 @@ function addMe() {
     expect(changesAfterLoad[0].textContent).toBe(`${koaServer.baseUrl}/test1`);
 
     await tab.interact([{ command: 'click', mousePosition: ['document', ['querySelector', 'a']] }]);
-
-    await tab.waitForElement(['document', ['querySelector', 'a#link2']]);
+    await Helpers.waitForElement(
+      ['document', ['querySelector', 'a#link2']],
+      tab.mainFrameEnvironment,
+    );
 
     const changes = await tab.getDomChanges(tab.mainFrameId, commandId);
     expect(changes).toHaveLength(2);
@@ -86,7 +88,7 @@ function removeMe() {
     expect(changesAfterLoad[0].textContent).toBe(`${koaServer.baseUrl}/test2`);
     const loadCommand = tab.lastCommandId;
 
-    await tab.waitForElement(['document', ['querySelector', 'a']]);
+    await Helpers.waitForElement(['document', ['querySelector', 'a']], tab.mainFrameEnvironment);
     await tab.interact([{ command: 'click', mousePosition: ['document', ['querySelector', 'a']] }]);
 
     await tab.waitForMillis(100);
@@ -132,7 +134,7 @@ function sort() {
     expect(changesAfterLoad[0].textContent).toBe(`${koaServer.baseUrl}/test3`);
     const loadCommand = tab.lastCommandId;
 
-    await tab.waitForElement(['document', ['querySelector', 'a']]);
+    await Helpers.waitForElement(['document', ['querySelector', 'a']], tab.mainFrameEnvironment);
     await tab.interact([{ command: 'click', mousePosition: ['document', ['querySelector', 'a']] }]);
 
     await tab.waitForMillis(100);
@@ -177,7 +179,7 @@ function sort() {
     expect(changesAfterLoad[0].textContent).toBe(`${koaServer.baseUrl}/test4`);
     const loadCommand = tab.lastCommandId;
 
-    await tab.waitForElement(['document', ['querySelector', 'a']]);
+    await Helpers.waitForElement(['document', ['querySelector', 'a']], tab.mainFrameEnvironment);
     await tab.interact([{ command: 'click', mousePosition: ['document', ['querySelector', 'a']] }]);
 
     await tab.waitForMillis(100);
@@ -268,7 +270,7 @@ function clickIt() {
     await tab.goto(`${koaServer.baseUrl}/cssom`);
     await tab.waitForLoad('DomContentLoaded');
 
-    await tab.waitForElement(['document', ['querySelector', 'a']]);
+    await Helpers.waitForElement(['document', ['querySelector', 'a']], tab.mainFrameEnvironment);
     await tab.interact([{ command: 'click', mousePosition: ['document', ['querySelector', 'a']] }]);
 
     await tab.waitForMillis(100);
@@ -317,7 +319,7 @@ customElements.define('image-list', class extends HTMLElement {
     await tab.goto(`${koaServer.baseUrl}/test5`);
     await tab.waitForLoad('DomContentLoaded');
 
-    await tab.waitForElement(['document', ['querySelector', 'a']]);
+    await Helpers.waitForElement(['document', ['querySelector', 'a']], tab.mainFrameEnvironment);
     await tab.interact([{ command: 'click', mousePosition: ['document', ['querySelector', 'a']] }]);
 
     await tab.waitForMillis(100);

--- a/core/test/frames.test.ts
+++ b/core/test/frames.test.ts
@@ -33,7 +33,7 @@ test('can wait for sub-frames to load', async () => {
       `;
   });
   await tab.goto(`${koaServer.baseUrl}/main`);
-  await tab.waitForElement(['document', ['querySelector', 'iframe']]);
+  await Helpers.waitForElement(['document', ['querySelector', 'iframe']], tab.mainFrameEnvironment);
 
   const frames = await tab.getFrameEnvironments();
   expect(frames).toHaveLength(2);

--- a/core/test/user-profile.test.ts
+++ b/core/test/user-profile.test.ts
@@ -443,7 +443,10 @@ document.querySelector('#local').innerHTML = localStorage.getItem('local');
       ]);
       expect(localContent.value).toBe('2');
 
-      await tab.waitForElement(['document', ['querySelector', '#cross.ready']]);
+      await Helpers.waitForElement(
+        ['document', ['querySelector', '#cross.ready']],
+        tab.mainFrameEnvironment,
+      );
       const crossContent = await tab.execJsPath([
         'document',
         ['querySelector', '#cross'],
@@ -482,7 +485,10 @@ describe('UserProfile IndexedDb tests', () => {
       Helpers.needsClosing.push(tab.session);
       await tab.goto(`${koaServer.baseUrl}/dbfail`);
       await tab.waitForLoad('PaintingStable');
-      await tab.waitForElement(['document', ['querySelector', 'body.ready']]);
+      await Helpers.waitForElement(
+        ['document', ['querySelector', 'body.ready']],
+        tab.mainFrameEnvironment,
+      );
 
       await expect(tab.session.exportUserProfile()).resolves.toBeTruthy();
     }
@@ -581,7 +587,10 @@ describe('UserProfile IndexedDb tests', () => {
       Helpers.needsClosing.push(tab.session);
       await tab.goto(`${koaServer.baseUrl}/db`);
       await tab.waitForLoad('PaintingStable');
-      await tab.waitForElement(['document', ['querySelector', 'body.ready']]);
+      await Helpers.waitForElement(
+        ['document', ['querySelector', 'body.ready']],
+        tab.mainFrameEnvironment,
+      );
 
       profile = await tab.session.exportUserProfile();
       expect(profile.storage[koaServer.baseUrl]?.indexedDB).toHaveLength(1);
@@ -607,7 +616,10 @@ describe('UserProfile IndexedDb tests', () => {
 
       await tab.goto(`${koaServer.baseUrl}/dbrestore`);
       await tab.waitForLoad('PaintingStable');
-      await tab.waitForElement(['document', ['querySelector', 'body.ready']]);
+      await Helpers.waitForElement(
+        ['document', ['querySelector', 'body.ready']],
+        tab.mainFrameEnvironment,
+      );
 
       const recordsJson = await tab.execJsPath<string>([
         'document',

--- a/docs/main/BasicInterfaces/Hero.md
+++ b/docs/main/BasicInterfaces/Hero.md
@@ -65,7 +65,7 @@ const Hero = require('@ulixee/hero');
 (async () => {
   // connection established here
   const hero = await new Hero({
-    userAgent: '~ mac 13.1 & chrome > 14'
+    userAgent: '~ mac 13.1 & chrome > 14',
   });
 })();
 ```
@@ -146,9 +146,9 @@ NOTE: if using the default hero, this object will be populated with command line
 
 ### hero.isAllContentLoaded {#is-all-content-loaded}
 
-`True` if the "load" event has triggered on the active tab. 
+`True` if the "load" event has triggered on the active tab.
 
-NOTE: this event does not fire in some circumstances (such as a long-loading asset). You frequently just want to know if the page has loaded for a user (see [isPaintingStable](#is-painting-stable)). 
+NOTE: this event does not fire in some circumstances (such as a long-loading asset). You frequently just want to know if the page has loaded for a user (see [isPaintingStable](#is-painting-stable)).
 
 Wait for this event to trigger with [Tab.waitForLoad(AllContentLoaded)](/docs/basic-interfaces/tab#wait-for-load).
 
@@ -159,7 +159,7 @@ Alias for [Tab.isAllContentLoaded](/docs/basic-interfaces/tab#is-all-content-loa
 ### hero.isDomContentLoaded {#is-dom-content-loaded}
 
 `True` if the "DOMContentLoaded" event has triggered on the active tab.
- 
+
 Wait for this event to trigger with [Tab.waitForLoad(DomContentLoaded)](/docs/basic-interfaces/tab#wait-for-load)
 
 #### **Type**: `Promise<boolean>`
@@ -168,7 +168,7 @@ Alias for [Tab.isDomContentLoaded](/docs/basic-interfaces/tab#is-dom-content-loa
 
 ### hero.isPaintingStable {#is-painting-stable}
 
-`True` if the page has loaded the main content above the fold. Works on javascript-rendered pages. 
+`True` if the page has loaded the main content above the fold. Works on javascript-rendered pages.
 
 Wait for this event to trigger with [Hero.waitForPaintingStable()](#wait-for-painting-stable)
 
@@ -231,13 +231,14 @@ const Hero = require('@ulixee/hero');
   const document = hero.document;
 
   for (const link of await document.querySelectorAll('a')) {
-    hero.output.push({ // will display in Replay UI.
+    hero.output.push({
+      // will display in Replay UI.
       text: await link.textContent,
       href: await link.href,
     });
   }
-   
-  console.log(hero.output);  
+
+  console.log(hero.output);
   await hero.close();
 })();
 ```
@@ -429,11 +430,11 @@ Refer to the [Interactions page](/docs/basic-interfaces/interactions) for detail
 
 ### hero.use*(plugin)*
 
-Add a plugin to the current instance. This must be called before any other hero methods. 
+Add a plugin to the current instance. This must be called before any other hero methods.
 
 #### **Arguments**:
 
-- plugin `ClientPlugin` | `array` | `object` | `string` 
+- plugin `ClientPlugin` | `array` | `object` | `string`
 
 #### **Returns**: `this` The same Hero instance (for optional chaining)
 
@@ -451,6 +452,7 @@ hero.use('@ulixee/tattle-plugin');
 The following three examples all work:
 
 Use an already-imported plugin:
+
 ```javascript
 import Hero from '@ulixee/hero';
 import ExecuteJsPlugin from '@ulixee/execute-js-plugin';
@@ -460,6 +462,7 @@ hero.use(ExecuteJsPlugin);
 ```
 
 Use an NPM package name (if it's publicly available):
+
 ```javascript
 import Hero from '@ulixee/hero';
 
@@ -468,6 +471,7 @@ hero.use('@ulixee/execute-js-plugin');
 ```
 
 Use an absolute path to file that exports one or more plugins:
+
 ```javascript
 import Hero from '@ulixee/hero';
 
@@ -504,6 +508,10 @@ Hero instances have aliases to all top-level Tab methods. They will be routed to
 ### hero.fetch*(requestInput, requestInit)* <div class="specs"><i>W3C</i></div> {#fetch}
 
 Alias for [Tab.fetch()](/docs/basic-interfaces/tab#fetch)
+
+### hero.findResource*(filter, options)* {#find-resource}
+
+Alias for [Tab.findResource()](/docs/basic-interfaces/tab#find-resource)
 
 ### hero.getFrameEnvironment*(frameElement)* {#get-frame-environment}
 

--- a/docs/main/BasicInterfaces/Tab.md
+++ b/docs/main/BasicInterfaces/Tab.md
@@ -170,6 +170,23 @@ Get the [FrameEnvironment](/docs/basic-interfaces/frame-environment) object corr
 
 Alias for [FrameEnvironment.getFrameEnvironment](/docs/basic-interfaces/frame-environment#get-frame-environment)
 
+### tab.findResource*(filter, options)* {#find-resource}
+
+Find a specific image, stylesheet, script, websocket or other resource that has been received. This function will return the most recently received resource first.
+
+#### **Arguments**:
+
+- filter `object` Match on "all" of the provided filters:
+  - url `string | RegExp` A string or regex to match a url.
+  - type [`ResourceType`](/docs/advanced/resource#type) A resource type to filter by.
+  - httpResource `object`
+    - statusCode `number` Http status code to filter by.
+    - method `string` Http request method to filter by.
+- options `object` Accepts any of the following:
+  - sinceCommandId `number`. A `commandId` from which to look for resources. Defaults to the last Http Navigation performed on the tab.
+
+#### **Returns**: [`Promise<Resource>`](/docs/advanced/resource)
+
 ### tab.focus*()* {#focus}
 
 Make this tab the `activeTab` within a browser, which directs many Hero methods to this tab.

--- a/fullstack/package.json
+++ b/fullstack/package.json
@@ -19,7 +19,7 @@
     "@ulixee/hero-plugin-utils": "1.5.4",
     "@ulixee/hero-timetravel": "1.5.4",
     "@ulixee/hero-testing": "1.5.4",
-    "awaited-dom": "1.3.1",
+    "awaited-dom": "1.3.2",
     "fpcollect": "^1.0.4",
     "fpscanner": "^0.1.5",
     "ws": "^7.4.6"

--- a/fullstack/test/document.test.ts
+++ b/fullstack/test/document.test.ts
@@ -29,7 +29,7 @@ describe('basic Document tests', () => {
     const links = await hero.document.querySelectorAll('a');
 
     for (const link of links) {
-      await hero.interact({ click: link, waitForElementVisible: link });
+      await hero.interact({ click: link });
       await hero.waitForLocation('change');
     }
     const finalUrl = await hero.url;

--- a/fullstack/test/interact.test.ts
+++ b/fullstack/test/interact.test.ts
@@ -94,33 +94,6 @@ describe('basic Interact tests', () => {
     await hero1.close();
   }, 20e3);
 
-  it('should be able to combine a waitForElementVisible and a click', async () => {
-    koaServer.get('/waitTest', ctx => {
-      ctx.body = `
-        <body>
-          <a href="/finish">Click Me</a>
-           <script>
-            setTimeout(() => {
-              document.querySelector('a').classList.add('ready');
-            }, 200);
-          </script>
-        </body>
-      `;
-    });
-    koaServer.get('/finish', ctx => (ctx.body = `Finished!`));
-    const hero = new Hero();
-    Helpers.needsClosing.push(hero);
-    await hero.goto(`${koaServer.baseUrl}/waitTest`);
-    await hero.waitForPaintingStable();
-    const readyLink = hero.document.querySelector('a.ready');
-    await hero.interact({ click: readyLink, waitForElementVisible: readyLink });
-    await hero.waitForLocation('change');
-    const finalUrl = await hero.url;
-    expect(finalUrl).toBe(`${koaServer.baseUrl}/finish`);
-
-    await hero.close();
-  });
-
   it('should be able to type various combinations of characters', async () => {
     koaServer.get('/keys', ctx => {
       ctx.body = `

--- a/fullstack/test/resources.test.ts
+++ b/fullstack/test/resources.test.ts
@@ -102,6 +102,20 @@ describe('basic resource tests', () => {
     }
   });
 
+  it('can find resources', async () => {
+    const exampleUrl = `${koaServer.baseUrl}/resources-test`;
+    const hero = new Hero();
+    Helpers.needsClosing.push(hero);
+
+    await hero.goto(exampleUrl);
+    await hero.waitForPaintingStable();
+    const elem = hero.document.querySelector('a');
+    await hero.click(elem);
+
+    await hero.waitForResource({ url: '/ajax?counter' });
+    await expect(hero.findResource({ url: '/ajax?counter=0' })).resolves.toBeTruthy();
+  });
+
   it('cancels a pending resource on hero close', async () => {
     const exampleUrl = `${koaServer.baseUrl}/resources-test`;
     const hero = new Hero();

--- a/fullstack/test/waitForElement.test.ts
+++ b/fullstack/test/waitForElement.test.ts
@@ -1,19 +1,11 @@
 import { Helpers } from '@ulixee/hero-testing';
 import { ITestKoaServer } from '@ulixee/hero-testing/helpers';
 import ISessionCreateOptions from '@ulixee/hero-interfaces/ISessionCreateOptions';
-import Core, { Tab } from '../index';
-import ConnectionToClient from '../connections/ConnectionToClient';
-import Session from '../lib/Session';
-import { getComputedVisibilityFnName } from '@ulixee/hero-interfaces/jsPathFnNames';
-import { INodeVisibility } from '@ulixee/hero-interfaces/INodeVisibility';
-import { IJsPath } from 'awaited-dom/base/AwaitedPath';
+import Hero from '../index';
+import Tab from '@ulixee/hero/lib/Tab';
 
 let koaServer: ITestKoaServer;
-let connection: ConnectionToClient;
 beforeAll(async () => {
-  connection = Core.addConnection();
-  await connection.connect();
-  Helpers.onClose(() => connection.disconnect(), true);
   koaServer = await Helpers.runKoaServer();
 });
 afterAll(Helpers.afterAll);
@@ -36,9 +28,7 @@ describe('basic waitForElement tests', () => {
     const { tab } = await createSession();
     await tab.goto(`${koaServer.baseUrl}/waitForElementTest1`);
 
-    await expect(tab.waitForElement(['document', ['querySelector', 'a']])).resolves.toMatchObject({
-      id: expect.any(Number),
-    });
+    await expect(tab.document.querySelector('a').$waitForExists()).resolves.toBeTruthy();
   });
 
   it('times out waiting for an element', async () => {
@@ -50,8 +40,8 @@ describe('basic waitForElement tests', () => {
     await tab.waitForLoad('DomContentLoaded');
 
     await expect(
-      tab.waitForElement(['document', ['querySelector', 'a#notthere']], { timeoutMs: 500 }),
-    ).rejects.toThrowError(/Timeout waiting for element to be visible/);
+      tab.querySelector('a#notthere').$waitForExists({ timeoutMs: 500 }),
+    ).rejects.toThrowError(/Timeout waiting for element to exist/);
   });
 
   it('will wait for an element to be visible', async () => {
@@ -68,14 +58,7 @@ describe('basic waitForElement tests', () => {
     const { tab } = await createSession();
     await tab.goto(`${koaServer.baseUrl}/waitForElementTest3`);
 
-    await expect(
-      tab.waitForElement(['document', ['querySelector', 'a#waitToShow']], {
-        waitForVisible: true,
-      }),
-    ).resolves.toMatchObject({
-      id: expect.any(Number),
-      type: 'HTMLAnchorElement',
-    });
+    await expect(tab.querySelector('a#waitToShow').$waitForVisible()).resolves.toBeTruthy();
   });
 
   it('can wait for an element to be visible with hidden parent', async () => {
@@ -98,35 +81,16 @@ describe('basic waitForElement tests', () => {
     await tab.goto(`${koaServer.baseUrl}/waitForElementParent`);
     await tab.waitForLoad('DomContentLoaded');
 
-    const qs: IJsPath = ['document', ['querySelector', 'a#child']];
-
-    const visibility = await tab.execJsPath<INodeVisibility>([
-      ...qs,
-      [getComputedVisibilityFnName],
-    ]);
-    expect(visibility.value.isVisible).toBe(true);
+    const visibility = await tab.getComputedVisibility(tab.querySelector('a#child'));
+    expect(visibility.isVisible).toBe(true);
 
     await tab.getJsValue('setTimeout(() => hide(), 100)');
 
-    await expect(
-      tab.waitForElement(qs, {
-        waitForHidden: true,
-      }),
-    ).resolves.toMatchObject({
-      id: expect.any(Number),
-      type: 'HTMLAnchorElement',
-    });
+    await expect(tab.querySelector('a#child').$waitForHidden()).resolves.toBeTruthy();
 
     await tab.getJsValue('setTimeout(() => show(), 100)');
 
-    await expect(
-      tab.waitForElement(qs, {
-        waitForVisible: true,
-      }),
-    ).resolves.toMatchObject({
-      id: expect.any(Number),
-      type: 'HTMLAnchorElement',
-    });
+    await expect(tab.querySelector('a#child').$waitForVisible()).resolves.toBeTruthy();
   });
 
   it('can wait for an element to be clickable', async () => {
@@ -137,20 +101,16 @@ describe('basic waitForElement tests', () => {
     setTimeout(function() {
       document.querySelector('a#waitToShow').style.display = 'block';
     }, 150);
+    setTimeout(function() {
+      document.querySelector('a#waitToShow').style.marginTop = 0;
+    }, 250);
 </script>
 </body>`;
     });
     const { tab } = await createSession();
     await tab.goto(`${koaServer.baseUrl}/waitForElementTestCustom`);
 
-    await expect(
-      tab.waitForElement(['document', ['querySelector', 'a#waitToShow']], {
-        waitForClickable: true,
-      }),
-    ).resolves.toMatchObject({
-      id: expect.any(Number),
-      type: 'HTMLAnchorElement',
-    });
+    await expect(tab.querySelector('a#waitToShow').$waitForClickable()).resolves.toBeTruthy();
   });
 
   it('will yield an error for a bad querySelector', async () => {
@@ -160,11 +120,9 @@ describe('basic waitForElement tests', () => {
     const { tab } = await createSession();
     await tab.goto(`${koaServer.baseUrl}/waitForElementBadQs`);
 
-    await expect(
-      tab.waitForElement(['document', ['querySelector', 'button-title="test"']], {
-        waitForVisible: true,
-      }),
-    ).rejects.toThrowError('valid selector');
+    await expect(tab.querySelector('button-title="test"').$waitForVisible()).rejects.toThrowError(
+      'valid selector',
+    );
   });
 
   it('will wait for a valid path to exist', async () => {
@@ -187,14 +145,10 @@ describe('basic waitForElement tests', () => {
     await tab.goto(`${koaServer.baseUrl}/waitForElementValidPath`);
 
     await expect(
-      tab.waitForElement(['document', ['querySelector', 'ul'], 'children', ['item', 2]], {
-        waitForVisible: true,
+      tab.querySelector('ul').children[2].$waitForVisible({
         timeoutMs: 5e3,
       }),
-    ).resolves.toMatchObject({
-      id: expect.any(Number),
-      type: 'HTMLLIElement',
-    });
+    ).resolves.toBeTruthy();
   });
 
   it('will find the correct center of an element', async () => {
@@ -209,32 +163,11 @@ describe('basic waitForElement tests', () => {
     const { tab } = await createSession();
     await tab.goto(`${koaServer.baseUrl}/waitForElementCenter`);
 
-    await expect(
-      tab.waitForElement(['document', ['querySelector', '#wrapper']], {
-        waitForVisible: true,
-      }),
-    ).resolves.toMatchObject({
-      id: expect.any(Number),
-      type: 'HTMLDivElement',
-    });
+    await expect(tab.querySelector('#wrapper').$waitForVisible()).resolves.toBeTruthy();
 
-    await expect(
-      tab.waitForElement(['document', ['querySelector', '#elem1']], {
-        waitForVisible: true,
-      }),
-    ).resolves.toMatchObject({
-      id: expect.any(Number),
-      type: 'HTMLDivElement',
-    });
+    await expect(tab.querySelector('#elem1').$waitForVisible()).resolves.toBeTruthy();
 
-    await expect(
-      tab.waitForElement(['document', ['querySelector', '#elem2']], {
-        waitForVisible: true,
-      }),
-    ).resolves.toMatchObject({
-      id: expect.any(Number),
-      type: 'HTMLDivElement',
-    });
+    await expect(tab.querySelector('#elem2').$waitForVisible()).resolves.toBeTruthy();
   });
 
   it('will wait for an element above the fold to be on screen', async () => {
@@ -251,14 +184,7 @@ describe('basic waitForElement tests', () => {
     const { tab } = await createSession();
     await tab.goto(`${koaServer.baseUrl}/waitForElementTestOnScreen`);
 
-    await expect(
-      tab.waitForElement(['document', ['querySelector', 'a#waitToShow']], {
-        waitForVisible: true,
-      }),
-    ).resolves.toMatchObject({
-      id: expect.any(Number),
-      type: 'HTMLAnchorElement',
-    });
+    await expect(tab.querySelector('a#waitToShow').$waitForVisible()).resolves.toBeTruthy();
   });
 
   it('will wait until an element off the bottom of the page comes into view', async () => {
@@ -277,14 +203,7 @@ describe('basic waitForElement tests', () => {
     const { tab } = await createSession();
     await tab.goto(`${koaServer.baseUrl}/waitForElementTestOffBottom`);
 
-    await expect(
-      tab.waitForElement(['document', ['querySelector', 'a#waitToShow']], {
-        waitForVisible: true,
-      }),
-    ).resolves.toMatchObject({
-      id: expect.any(Number),
-      type: 'HTMLAnchorElement',
-    });
+    await expect(tab.querySelector('a#waitToShow').$waitForVisible()).resolves.toBeTruthy();
   });
 
   it('can wait for an element to be hidden', async () => {
@@ -305,20 +224,15 @@ describe('basic waitForElement tests', () => {
 
     try {
       // In this case, the element might be null if removed and cleaned up depending on timing. We need to just wait
-      await tab.waitForElement(['document', ['querySelector', 'a#waitToRemove']], {
-        waitForHidden: true,
-      });
+      await tab.querySelector('a#waitToRemove').$waitForHidden();
     } catch (err) {
       expect(err).not.toBeTruthy();
     }
   });
 });
 
-async function createSession(
-  options?: ISessionCreateOptions,
-): Promise<{ session: Session; tab: Tab }> {
-  const meta = await connection.createSession(options);
-  const tab = Session.getTab(meta);
-  Helpers.needsClosing.push(tab.session);
-  return { session: tab.session, tab };
+async function createSession(options?: ISessionCreateOptions): Promise<{ tab: Tab; hero: Hero }> {
+  const hero = new Hero(options);
+  Helpers.needsClosing.push(hero);
+  return { tab: hero.activeTab, hero };
 }

--- a/fullstack/test/waitForLocation.test.ts
+++ b/fullstack/test/waitForLocation.test.ts
@@ -76,14 +76,14 @@ describe('basic waitForLocation change detections', () => {
     Helpers.needsClosing.push(hero);
     await hero.goto(`${koaServer.baseUrl}/page1`);
     await hero.waitForPaintingStable();
-    const startlink = hero.document.querySelector('a');
-    await hero.interact({ click: startlink, waitForElementVisible: startlink });
+    const startlink = await hero.document.querySelector('a').$waitForVisible();
+    await hero.interact({ click: startlink });
     await hero.waitForLocation('change');
     await hero.waitForPaintingStable();
     expect(await hero.url).toBe(`${koaServer.baseUrl}/page3`);
 
-    const nextlink = hero.document.querySelector('a');
-    await hero.interact({ click: nextlink, waitForElementVisible: nextlink });
+    const nextlink = await hero.document.querySelector('a').$waitForVisible();
+    await hero.interact({ click: nextlink });
     await hero.waitForLocation('change');
     await hero.waitForPaintingStable();
     expect(await hero.url).toBe(`${koaServer.baseUrl}/finish`);
@@ -117,14 +117,14 @@ describe('basic waitForLocation change detections', () => {
     await hero.goto(startUrl);
     const firstUrl = await hero.url;
     await hero.waitForPaintingStable();
-    const readyLink = hero.document.querySelector('a');
-    await hero.interact({ click: readyLink, waitForElementVisible: readyLink });
+    const readyLink = await hero.document.querySelector('a').$waitForVisible();
+    await hero.interact({ click: readyLink });
     await hero.waitForLocation('change');
     const secondUrl = await hero.url;
     await hero.waitForPaintingStable();
 
-    const readyLink2 = hero.document.querySelector('a');
-    await hero.interact({ click: readyLink2, waitForElementVisible: readyLink2 });
+    const readyLink2 = await hero.document.querySelector('a').$waitForVisible();
+    await hero.interact({ click: readyLink2 });
     await hero.waitForLocation('change');
     await hero.waitForPaintingStable();
     const lastUrl = await hero.url;

--- a/interfaces/IInteractions.ts
+++ b/interfaces/IInteractions.ts
@@ -41,8 +41,6 @@ export enum InteractionCommand {
 
   type = 'type',
 
-  waitForNode = 'waitForNode',
-  waitForElementVisible = 'waitForElementVisible',
   waitForMillis = 'waitForMillis',
 }
 

--- a/interfaces/IResourceFilterProperties.ts
+++ b/interfaces/IResourceFilterProperties.ts
@@ -1,4 +1,4 @@
-import IResourceType from '@ulixee/hero-interfaces/IResourceType';
+import IResourceType from './IResourceType';
 
 export default interface IResourceFilterProperties {
   url?: string | RegExp;

--- a/interfaces/package.json
+++ b/interfaces/package.json
@@ -3,7 +3,7 @@
   "version": "1.5.4",
   "description": "Core interfaces used by Hero",
   "dependencies": {
-    "awaited-dom": "1.3.1",
+    "awaited-dom": "1.3.2",
     "@ulixee/commons": "1.5.9",
     "devtools-protocol": "^0.0.799653"
   }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/node": "^13.13.52",
     "@typescript-eslint/eslint-plugin": "^5.10.1",
     "@typescript-eslint/parser": "^5.1.0",
-    "awaited-dom": "^1.3.1",
+    "awaited-dom": "^1.3.2",
     "copyfiles": "^2.4.1",
     "cross-env": "^7.0.3",
     "decamelize": "^4.0.0",

--- a/timetravel/lib/DomStateGenerator.ts
+++ b/timetravel/lib/DomStateGenerator.ts
@@ -9,7 +9,7 @@ import DomChangesTable, {
 import SessionDb from '@ulixee/hero-core/dbs/SessionDb';
 import IResourceSummary from '@ulixee/hero-interfaces/IResourceSummary';
 import IDomStateAssertionBatch from '@ulixee/hero-interfaces/IDomStateAssertionBatch';
-import IResourceFilterProperties from '@ulixee/hero-core/interfaces/IResourceFilterProperties';
+import IResourceFilterProperties from '@ulixee/hero-interfaces/IResourceFilterProperties';
 import { NodeType } from './DomNode';
 import DomRebuilder from './DomRebuilder';
 import MirrorPage from './MirrorPage';

--- a/timetravel/lib/DomStateGenerator.ts
+++ b/timetravel/lib/DomStateGenerator.ts
@@ -2,6 +2,7 @@ import { DomActionType } from '@ulixee/hero-interfaces/IDomChangeEvent';
 import Log from '@ulixee/commons/lib/Logger';
 import IPuppetContext from '@ulixee/hero-interfaces/IPuppetContext';
 import { IFrameNavigationRecord } from '@ulixee/hero-core/models/FrameNavigationsTable';
+import { CanceledPromiseError } from '@ulixee/commons/interfaces/IPendingWaitEvent';
 import DomChangesTable, {
   IDomChangeRecord,
   IDomRecording,
@@ -161,6 +162,9 @@ export default class DomStateGenerator {
     this.isEvaluating = true;
     try {
       await this.doEvaluate();
+    } catch (error) {
+      if (error instanceof CanceledPromiseError) return;
+      throw error;
     } finally {
       this.isEvaluating = false;
 

--- a/timetravel/test/DomStateGenerator.test.ts
+++ b/timetravel/test/DomStateGenerator.test.ts
@@ -200,7 +200,10 @@ describe('domStateGenerator', () => {
       await tab.goto(`${koaServer.baseUrl}/storage?state=cookieValue`);
       await tab.waitForLoad(LoadStatus.PaintingStable);
       await tab.getJsValue(`storage()`);
-      await tab.waitForElement(['document', ['querySelector', '.db-ready']]);
+      await Helpers.waitForElement(
+        ['document', ['querySelector', '.db-ready']],
+        tab.mainFrameEnvironment,
+      );
       await tab.flushDomChanges();
       await session.close();
 
@@ -300,7 +303,10 @@ describe('domStateGenerator', () => {
       const startTime = Date.now();
 
       await tab.waitForLoad(LoadStatus.PaintingStable);
-      await tab.waitForElement(['document', ['querySelector', '#ready']]);
+      await Helpers.waitForElement(
+        ['document', ['querySelector', '#ready']],
+        tab.mainFrameEnvironment,
+      );
 
       await session.close();
       domStateGenerator.addSession(session.db, tab.id, [startTime, Date.now()]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2058,14 +2058,6 @@
     progress "^2.0.3"
     tar "^6.1.0"
 
-"@ulixee/commons@1.5.9":
-  version "1.5.9"
-  resolved "https://registry.yarnpkg.com/@ulixee/commons/-/commons-1.5.9.tgz#baf512c59057138f466c339c98a01855111f7a4e"
-  integrity sha512-YQBLnELOEXebagcyHHudMfymuJaLj7jo6EURxspxiviz+NVMG0xTwO3nglIOwtCPLaS1zjArxp8lbKzGkJXLKQ==
-  dependencies:
-    https-proxy-agent "^5.0.0"
-    source-map-js "^1.0.1"
-
 JSONStream@^1.0.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -2371,10 +2363,10 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-awaited-dom@1.3.1, awaited-dom@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/awaited-dom/-/awaited-dom-1.3.1.tgz#30d9daa86a85b7f55c96914d09f4ea4a257b958f"
-  integrity sha512-v6gwyQucUjfwyTHaYWTW3dt9X1aELcUMT8ov6m5pkWnadCmK4ZyfrfEtu67Tc4g6/8tG1UKBwnno5DVL6GURqg==
+awaited-dom@1.3.2, awaited-dom@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/awaited-dom/-/awaited-dom-1.3.2.tgz#90f044bda2d3329b74518acea6300968439a67ad"
+  integrity sha512-sShOBw8zGlXrUEEt9DTAB2FtB8qoNkMl0y8VLbpEoX0akWffe1WKZAmqlXVIA1N3HPMjV/Nf+m3S2qCzcMyl8g==
 
 aws-sign2@~0.7.0:
   version "0.7.0"


### PR DESCRIPTION
This PR does 3 main things:
1) FindResources is exposed to client - so you can now find resources without doing a "waitFor". It will find most recent resources "first", so you could run it twice in a row and get a new result. By default, this feature looks "since the last Http Navigation".
2) WaitForElement is now a simple waitForState handler that uses getComputedVisibility changes. This is actually slightly more efficient than waitForElement, which just looped in the dom. It now only re-checks when there are dom changes, or 2 seconds have gone by.
3) WaitForState functions that fail now invoke FlowHandlers to attempt recovery.

Chore:
- Consolidated spelling of "CallSite" to "Callsite". NOTE: we can't change Hero and Ulixee/commons at the same time, so there's one remaining spot to change. They have a co-dependency on the spelling.