### PR TITLE
Syntax changes and renames to State and Flow Handlers

### DIFF
--- a/client/lib/CoreFrameEnvironment.ts
+++ b/client/lib/CoreFrameEnvironment.ts
@@ -151,7 +151,7 @@ export default class CoreFrameEnvironment {
     try {
       await this.coreTab.waitForState(
         {
-          allTrue({ assert }) {
+          all(assert) {
             if (waitForVisible) assert(element.$isVisible);
             else if (waitForClickable) assert(element.$isClickable);
             else if (waitForHidden) assert(element.$isVisible, false);

--- a/client/lib/DomState.ts
+++ b/client/lib/DomState.ts
@@ -3,11 +3,11 @@ import IDomState, { IDomStateAssertions } from '@ulixee/hero-interfaces/IDomStat
 export default class DomState implements IDomState {
   public name?: string;
   public url?: string | RegExp;
-  public allTrue: (options: IDomStateAssertions) => void;
+  public all: (options: IDomStateAssertions) => void;
 
   constructor(options: IDomState) {
     this.name = options.name;
     this.url = options.url;
-    this.allTrue = options.allTrue;
+    this.all = options.all;
   }
 }

--- a/client/lib/DomStateHandler.ts
+++ b/client/lib/DomStateHandler.ts
@@ -185,11 +185,11 @@ export default class DomStateHandler {
   private async createAssertionSets(): Promise<IStateAndAssertion<any>[]> {
     const assertionSets: IStateAndAssertion<any>[] = [];
 
-    this.domState.allTrue({
-      assert(statePromise, assertion) {
+    this.domState.all(
+      function assert(statePromise, assertion) {
         assertionSets.push([Promise.resolve(statePromise).catch(err => err), assertion]);
-      },
-    });
+      }
+    );
 
     // wait for all to complete
     for (const assertion of assertionSets) {
@@ -219,11 +219,11 @@ export default class DomStateHandler {
       async () => {
         const runCommands: Promise<any>[] = [];
         // trigger a run so we can see commands that get triggered
-        result = this.domState.allTrue({
-          assert: statePromise => {
+        result = this.domState.all(
+          function assert(statePromise) {
             runCommands.push(Promise.resolve(statePromise).catch(() => null));
-          },
-        });
+          }
+        );
         await Promise.all(runCommands);
       },
     );
@@ -232,7 +232,7 @@ export default class DomStateHandler {
       throw new Error(
         `DomState (${
           this.domState.name ?? 'no name'
-        }) allTrue({ assert }) returns a Promise. Each state function must have synchronous assertions.`,
+        }) all(assert) returns a Promise. Each state function must have synchronous assertions.`,
       );
     }
   }

--- a/client/lib/Hero.ts
+++ b/client/lib/Hero.ts
@@ -59,7 +59,7 @@ import CoreFrameEnvironment from './CoreFrameEnvironment';
 import './DomExtender';
 import ICollectedResource from '@ulixee/hero-interfaces/ICollectedResource';
 import ICollectedFragment from '@ulixee/hero-interfaces/ICollectedFragment';
-import IDomState from '@ulixee/hero-interfaces/IDomState';
+import IDomState, { IDomStateAllFn } from '@ulixee/hero-interfaces/IDomState';
 import DomState from './DomState';
 import ConnectionToCore from '../connections/ConnectionToCore';
 import CoreSession from './CoreSession';
@@ -503,25 +503,25 @@ export default class Hero extends AwaitedEventTarget<{
   }
 
   public async waitForState(
-    state: IDomState | DomState,
+    state: IDomState | DomState | IDomStateAllFn,
     options?: Pick<IWaitForOptions, 'timeoutMs'>,
   ): Promise<void> {
     return await this.activeTab.waitForState(state, options);
   }
 
-  public async checkState(state: IDomState | DomState): Promise<boolean> {
-    return await this.activeTab.checkState(state);
+  public async validateState(state: IDomState | DomState | IDomStateAllFn): Promise<boolean> {
+    return await this.activeTab.validateState(state);
   }
 
   public async registerFlowHandler(
-    state: IDomState | DomState,
+    state: IDomState | DomState | IDomStateAllFn,
     handlerCallbackFn: (error?: Error) => Promise<any>,
   ): Promise<void> {
     return await this.activeTab.registerFlowHandler(state, handlerCallbackFn);
   }
 
-  public async checkFlowHandlers(): Promise<void> {
-    return await this.activeTab.checkFlowHandlers();
+  public async triggerFlowHandlers(): Promise<void> {
+    return await this.activeTab.triggerFlowHandlers();
   }
 
   /////// THENABLE ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/client/lib/Tab.ts
+++ b/client/lib/Tab.ts
@@ -36,7 +36,7 @@ import IAwaitedOptions from '../interfaces/IAwaitedOptions';
 import Dialog from './Dialog';
 import FileChooser from './FileChooser';
 import DomState from './DomState';
-import IDomState from '@ulixee/hero-interfaces/IDomState';
+import IDomState, { IDomStateAllFn } from '@ulixee/hero-interfaces/IDomState';
 import InternalProperties from './InternalProperties';
 
 const awaitedPathState = StateMachine<
@@ -241,21 +241,21 @@ export default class Tab extends AwaitedEventTarget<IEventType> {
   }
 
   public async waitForState(
-    state: IDomState | DomState,
+    state: IDomState | DomState | IDomStateAllFn,
     options: Pick<IWaitForOptions, 'timeoutMs'> = { timeoutMs: 30e3 },
   ): Promise<void> {
     const coreTab = await this.#coreTabPromise;
     return coreTab.waitForState(state, options);
   }
 
-  public async checkState(state: IDomState | DomState): Promise<boolean> {
+  public async validateState(state: IDomState | DomState | IDomStateAllFn): Promise<boolean> {
     const callsitePath = scriptInstance.getScriptCallsite();
     const coreTab = await this.#coreTabPromise;
-    return coreTab.checkState(state, callsitePath);
+    return coreTab.validateState(state, callsitePath);
   }
 
   public async registerFlowHandler(
-    state: IDomState | DomState,
+    state: IDomState | DomState | IDomStateAllFn,
     handlerFn: (error?: Error) => Promise<any>,
   ): Promise<void> {
     const callsitePath = scriptInstance.getScriptCallsite();
@@ -264,9 +264,9 @@ export default class Tab extends AwaitedEventTarget<IEventType> {
     await coreTab.registerFlowHandler(state, handlerFn, callsitePath);
   }
 
-  public async checkFlowHandlers(): Promise<void> {
+  public async triggerFlowHandlers(): Promise<void> {
     const coreTab = await this.#coreTabPromise;
-    await coreTab.checkFlowHandlers();
+    await coreTab.triggerFlowHandlers();
   }
 
   public waitForResource(

--- a/core/lib/DomStateListener.ts
+++ b/core/lib/DomStateListener.ts
@@ -86,7 +86,7 @@ export default class DomStateListener extends TypedEventEmitter<IDomStateEvents>
 
     tab.once('close', this.stop);
     this.bindFrameEvents();
-    this.checkInterval = setInterval(this.checkState, 2e3).unref();
+    this.checkInterval = setInterval(this.validateState, 2e3).unref();
   }
 
   public stop(result?: { didMatch: boolean; error?: Error }): void {
@@ -102,8 +102,8 @@ export default class DomStateListener extends TypedEventEmitter<IDomStateEvents>
     for (const frameId of this.watchedFrameIds) {
       const frame = this.tab.getFrameEnvironment(frameId);
       if (!frame) continue;
-      frame.off('paint', this.checkState);
-      frame.navigations.off('status-change', this.checkState);
+      frame.off('paint', this.validateState);
+      frame.navigations.off('status-change', this.validateState);
     }
   }
 
@@ -218,7 +218,7 @@ export default class DomStateListener extends TypedEventEmitter<IDomStateEvents>
       this.trackCommand(id, frameId, command, args);
     }
 
-    setImmediate(this.checkState);
+    setImmediate(this.validateState);
   }
 
   private trackCommand(id: string, frameId: number, command: string, args: any[]): void {
@@ -235,8 +235,8 @@ export default class DomStateListener extends TypedEventEmitter<IDomStateEvents>
     if (!this.watchedFrameIds.has(frame.id)) {
       this.watchedFrameIds.add(frame.id);
 
-      frame.on('paint', this.checkState);
-      frame.navigations.on('status-change', this.checkState);
+      frame.on('paint', this.validateState);
+      frame.navigations.on('status-change', this.validateState);
     }
   }
 
@@ -250,7 +250,7 @@ export default class DomStateListener extends TypedEventEmitter<IDomStateEvents>
     this.lastResults = stringifiedResults;
   }
 
-  private async checkState(): Promise<void> {
+  private async validateState(): Promise<void> {
     if (this.shouldStop()) return;
     if (this.isCheckingState) {
       this.runAgainTime = Date.now();
@@ -272,7 +272,7 @@ export default class DomStateListener extends TypedEventEmitter<IDomStateEvents>
     } finally {
       this.isCheckingState = false;
       if (this.runAgainTime > 0)
-        setTimeout(this.checkState, Date.now() - this.runAgainTime).unref();
+        setTimeout(this.validateState, Date.now() - this.runAgainTime).unref();
     }
   }
 

--- a/docs/main/BasicInterfaces/Hero.md
+++ b/docs/main/BasicInterfaces/Hero.md
@@ -573,7 +573,7 @@ Alias for [Tab.waitForLocation](/docs/basic-interfaces/tab#wait-for-location)
 
 Alias for [Tab.waitForMillis](/docs/basic-interfaces/tab#wait-for-millis)
 
-### hero.waitForState*(states, options)* {#wait-for-state}
+### hero.waitForState*(state, options)* {#wait-for-state}
 
 Alias for [Tab.waitForState](/docs/basic-interfaces/tab#wait-for-state)
 

--- a/docs/main/BasicInterfaces/Tab.md
+++ b/docs/main/BasicInterfaces/Tab.md
@@ -375,7 +375,7 @@ await activeTab.waitForElement(elem, {
 });
 ```
 
-### tab.waitForState*(states, options)* {#wait-for-state}
+### tab.waitForState*(state, options)* {#wait-for-state}
 
 Wait for a state to be loaded based on a series of conditions. This feature allows you to detect when many different conditions all resolve to true.
 
@@ -388,7 +388,7 @@ NOTE: Null access exceptions are ignored, so you don't need to worry about indiv
 ```
  await hero.waitForState({
   name: 'ulixeeLoaded',
-  allTrue({ assert }) {
+  all(assert) {
     assert(hero.url, url => url === 'https://ulixee.org'); // once the url is resolved, it will be checked against https://ulixee.org
     assert(hero.isPaintingStable); // the default function evaluates if the result is true
   }
@@ -398,7 +398,7 @@ NOTE: Null access exceptions are ignored, so you don't need to worry about indiv
  
  await hero.waitForState({
   name: 'dlfLoaded',
-  allTrue({ assert }) {
+  all(assert) {
     assert(hero.url, 'https://dataliberationfoundation.org'); // a value will be tested for equality
     assert(hero.isPaintingStable);
     assert(hero.document.querySelector('h1').textContent, text => text === "It's Time to Open the Data Economy");
@@ -408,10 +408,10 @@ NOTE: Null access exceptions are ignored, so you don't need to worry about indiv
 
 #### **Arguments**:
 
-- states `object`
+- state `object`
   - name? `string`. Optional name of the state
   - url? `string` | `Regexp`. Optional url to run this state on (useful for running in a loop)
-  - allTrue `({ assert: IPageStateAssert }) => void`. A synchronous function that will be true if all assertions evaluate to true. 
+  - all `(assert: IPageStateAssert) => void`. A synchronous function that will be true if all assertions evaluate to true. 
     - assert `function(statePromise: Promise<T>, assertionValueOrCallbackFn: (result: T) => boolean): void`. A function that takes a Promise as a first parameter, and a callback that will be checked when new state is available. 
       - statePromise `PromiseLike<T>` A Hero Promise that issues a command against this tab (url, isPaintingStable, domElement, isVisible, etc).
       - assertionValueOrCallbackFn `value: T | function(state: T): boolean`. A function that will receive updated state as it becomes available. You should synchronously evaluate to true/false. If this parameter is a non-function, it will be compared for equality.

--- a/fullstack/test/domState.test.ts
+++ b/fullstack/test/domState.test.ts
@@ -19,15 +19,15 @@ test('can wait for a url', async () => {
   await hero.goto(`${koaServer.baseUrl}/waitForDomState1`);
   const state1 = hero.activeTab.waitForState({
     name: 'state1',
-    allTrue({ assert }) {
+    all(assert) {
       assert(hero.url, url => url.includes('waitForDomState'));
     },
   });
   await expect(state1).resolves.toBeUndefined();
 
-  const state2 = hero.activeTab.checkState({
+  const state2 = hero.activeTab.validateState({
     name: 'state2',
-    allTrue({ assert }) {
+    all(assert ) {
       assert(hero.url, url => url.includes('page2'));
     },
   });
@@ -52,12 +52,12 @@ setInterval(() => {
 
   await hero.goto(`${koaServer.baseUrl}/waitForDomState2`);
   const domState = {
-    allTrue({ assert }) {
+    all(assert) {
       assert(hero.document.querySelectorAll('div').length, x => x >= 4);
     },
   };
   await expect(hero.activeTab.waitForState(domState)).resolves.toBeUndefined();
-  await expect(hero.activeTab.checkState(domState)).resolves.toBe(true);
+  await expect(hero.activeTab.validateState(domState)).resolves.toBe(true);
 });
 
 test('can test for page state across redirects', async () => {
@@ -91,14 +91,14 @@ test('can test for page state across redirects', async () => {
   await hero.click(hero.document.querySelector('a'));
 
   const state = new DomState({
-    allTrue({ assert }) {
+    all(assert) {
       assert(hero.url, x => x.includes('waitForDomStateRedirectLast'));
       assert(hero.isPaintingStable);
       assert(hero.document.querySelector('h1').dataset, x => x.final === 'true');
     },
   });
   await expect(hero.activeTab.waitForState(state)).resolves.toBeUndefined();
-  await expect(hero.activeTab.checkState(state)).resolves.toBe(true);
+  await expect(hero.activeTab.validateState(state)).resolves.toBe(true);
 });
 
 test('surfaces errors in assertions', async () => {
@@ -107,7 +107,7 @@ test('surfaces errors in assertions', async () => {
   });
   const hero = await openBrowser('/waitForDomStateError');
   const domState = {
-    allTrue({ assert }) {
+    all(assert) {
       // @ts-ignore
       assert(hero.document.querySelector('h1').getAttribute('id'), x => test.includes(x));
     },
@@ -117,7 +117,7 @@ test('surfaces errors in assertions', async () => {
     'test.includes is not a function',
   );
 
-  await expect(hero.activeTab.checkState(domState)).rejects.toThrowError(
+  await expect(hero.activeTab.validateState(domState)).rejects.toThrowError(
     'test.includes is not a function',
   );
 });
@@ -129,7 +129,7 @@ test('surfaces errors in query selectors that are invalid (vs simply not there)'
   const hero = await openBrowser('/waitForDomStateSelectorError');
 
   const state = new DomState({
-    allTrue({ assert }) {
+    all(assert) {
       // @ts-ignore
       assert(hero.document.querySelector('h1[id@1]').getAttribute('id'), '1');
     },

--- a/fullstack/test/flowHandlers.test.ts
+++ b/fullstack/test/flowHandlers.test.ts
@@ -31,16 +31,14 @@ test('will trigger a flow handler when an error occurs', async () => {
   const spy = jest.fn();
 
   await hero.registerFlowHandler(
-    {
-      allTrue({ assert }) {
-        assert(hero.querySelector('.ready').$isVisible, false);
-      },
+    assert => {
+      assert(hero.querySelector('.ready').$isVisible, false);
     },
     async error => {
       spy();
       expect(error).not.toBeTruthy();
       await hero.querySelector('.make-ready').$click();
-    },
+    }
   );
 
   expect(spy).not.toHaveBeenCalled();
@@ -65,7 +63,7 @@ test('bubbles up handler errors to the line of code that triggers the handlers',
 
   await hero.registerFlowHandler(
     {
-      allTrue({ assert }) {
+      all(assert) {
         assert(hero.querySelector('.ready').$isVisible, false);
       },
     },
@@ -110,7 +108,7 @@ test('checks multiple handlers', async () => {
 
   await hero.registerFlowHandler(
     {
-      allTrue({ assert }) {
+      all(assert) {
         assert(hero.querySelector('.popup').$isVisible);
       },
     },
@@ -123,7 +121,7 @@ test('checks multiple handlers', async () => {
   const linkSpy = jest.fn();
   await hero.registerFlowHandler(
     {
-      allTrue({ assert }) {
+      all(assert) {
         assert(hero.querySelector('.wanted').$isVisible, false);
       },
     },

--- a/interfaces/IDomState.ts
+++ b/interfaces/IDomState.ts
@@ -1,17 +1,17 @@
 export default interface IDomState {
   name?: string;
   url?: string | RegExp;
-  allTrue(options: IDomStateAssertions): void;
+  all: IDomStateAllFn;
 }
+
+export type IDomStateAllFn = (options: IDomStateAssertions) => void;
 
 export type IStateAndAssertion<T> = [
   statePromise: Promise<T> | PromiseLike<T>,
   assertionFnOrValue?: ((state: T) => boolean) | T,
 ];
 
-export interface IDomStateAssertions {
-  assert<T>(
-    statePromise: Promise<T> | PromiseLike<T>,
-    assertionFnOrValue?: ((state: T) => boolean) | T,
-  ): void;
-}
+export type IDomStateAssertions = <T>(
+  statePromise: Promise<T> | PromiseLike<T>,
+  assertionFnOrValue?: ((state: T) => boolean) | T,
+) => void;


### PR DESCRIPTION
All of these except the last are ones we discussed yesterday. I implemented them in Hero to see if it made my scripts feel simpler and they did, so I submitted a PR.

1) The `allTrue` in State has been simplified down to just `all` with the first argument being `assert` and not `{ assert }`:

```
hero.waitForState({
  all(assert) {
    ....
  }
});
```

2) The State Methods (checkState, waitForState, and registerFlowHandler) now accept a simplified first argument of just the `all(assert)` callback:

```
hero.waitForState(assert => {
  ....
});
```

3) `checkFlowHandlers` has been renamed to `triggerFlowHandlers` to be more precise in what it does.

4) `checkState` has been renamed to `validateState`. I understand why we went with "checkState" as "ensureState" wasn't quite accurate (it doesn't actually ensure anything, it just returns a boolean). However, check never felt right in my script flow; I want it for a purpose, to validate the current state. Anyway, I'm cool reverting back to "checkState" if you want.

One thought... We've discussed wanting to pass state assertion results into Flow Handler callbacks. Similarly, returning a "validation object" from `validateState` of what assertions passed would be really nice and further lean towards the `validateState` name.