### PR TITLE
feat(client): focus and xpath dom extenders

### DIFF
--- a/client/lib/FrameEnvironment.ts
+++ b/client/lib/FrameEnvironment.ts
@@ -5,6 +5,7 @@ import { ISuperElement, ISuperNode, ISuperNodeList } from 'awaited-dom/base/inte
 import AwaitedPath from 'awaited-dom/base/AwaitedPath';
 import { IRequestInit } from 'awaited-dom/base/interfaces/official';
 import SuperDocument from 'awaited-dom/impl/super-klasses/SuperDocument';
+import XPathResult from 'awaited-dom/impl/official-klasses/XPathResult';
 import Storage from 'awaited-dom/impl/official-klasses/Storage';
 import CSSStyleDeclaration from 'awaited-dom/impl/official-klasses/CSSStyleDeclaration';
 import {
@@ -217,6 +218,34 @@ export default class FrameEnvironment {
     const awaitedPath = new AwaitedPath(null, 'document', ['querySelectorAll', selector]);
     const awaitedOptions: IAwaitedOptions = { coreFrame: this.#coreFramePromise };
     return createSuperNodeList(awaitedPath, awaitedOptions);
+  }
+
+  public xpathSelector(xpath: string, orderedNodeResults = false): ISuperNode {
+    return this.document.evaluate(
+      xpath,
+      this.document,
+      null,
+      orderedNodeResults
+        ? XPathResult.FIRST_ORDERED_NODE_TYPE
+        : XPathResult.ANY_UNORDERED_NODE_TYPE,
+    ).singleNodeValue;
+  }
+
+  public async xpathSelectorAll(xpath: string, orderedNodeResults = false): Promise<ISuperNode[]> {
+    const results = await this.document.evaluate(
+      xpath,
+      this.document,
+      null,
+      orderedNodeResults
+        ? XPathResult.ORDERED_NODE_ITERATOR_TYPE
+        : XPathResult.UNORDERED_NODE_ITERATOR_TYPE,
+    );
+    const nodes: ISuperNode[] = [];
+    let node: ISuperNode;
+    while ((node = await results.iterateNext())) {
+      nodes.push(node);
+    }
+    return nodes;
   }
 
   public async waitForPaintingStable(options?: IWaitForOptions): Promise<void> {

--- a/client/lib/Hero.ts
+++ b/client/lib/Hero.ts
@@ -468,6 +468,14 @@ export default class Hero extends AwaitedEventTarget<{
     return this.activeTab.querySelectorAll(selector);
   }
 
+  public xpathSelector(xpath: string, orderedNodeResults = false): ISuperNode {
+    return this.activeTab.xpathSelector(xpath, orderedNodeResults);
+  }
+
+  public xpathSelectorAll(xpath: string, orderedNodeResults = false): Promise<ISuperNode[]> {
+    return this.activeTab.xpathSelectorAll(xpath, orderedNodeResults);
+  }
+
   public takeScreenshot(options?: IScreenshotOptions): Promise<Buffer> {
     return this.activeTab.takeScreenshot(options);
   }

--- a/client/lib/Tab.ts
+++ b/client/lib/Tab.ts
@@ -220,6 +220,14 @@ export default class Tab extends AwaitedEventTarget<IEventType> {
     return this.mainFrameEnvironment.querySelectorAll(selector);
   }
 
+  public xpathSelector(xpath: string, orderedNodeResults = false): ISuperNode {
+    return this.mainFrameEnvironment.xpathSelector(xpath, orderedNodeResults);
+  }
+
+  public xpathSelectorAll(xpath: string, orderedNodeResults = false): Promise<ISuperNode[]> {
+    return this.mainFrameEnvironment.xpathSelectorAll(xpath, orderedNodeResults);
+  }
+
   public async takeScreenshot(options?: IScreenshotOptions): Promise<Buffer> {
     const coreTab = await this.#coreTabPromise;
     return coreTab.takeScreenshot(options);

--- a/core/injected-scripts/jsPath.ts
+++ b/core/injected-scripts/jsPath.ts
@@ -365,6 +365,10 @@ class ObjectAtPath {
     return this;
   }
 
+  public isFocused(): boolean {
+    return this.closestElement === document.activeElement;
+  }
+
   public toReturnError(error: Error): IExecJsPathResult {
     const pathError = <IJsPathError>{
       error: String(error),

--- a/fullstack/test/domExtenders.test.ts
+++ b/fullstack/test/domExtenders.test.ts
@@ -1,0 +1,64 @@
+import { Helpers } from '@ulixee/hero-testing';
+import { ITestKoaServer } from '@ulixee/hero-testing/helpers';
+import Hero from '../index';
+
+let koaServer: ITestKoaServer;
+beforeAll(async () => {
+  koaServer = await Helpers.runKoaServer();
+});
+afterAll(Helpers.afterAll);
+afterEach(Helpers.afterEach);
+
+describe('basic DomExtender tests', () => {
+  it('can run xpathSelector', async () => {
+    koaServer.get('/domextender-xpath', ctx => {
+      ctx.body = `
+        <body>
+          <h2>here</h2>
+        </body>
+      `;
+    });
+    const hero = await openBrowser(`/domextender-xpath`);
+
+    await expect(hero.xpathSelector('//h2').textContent).resolves.toBe('here');
+  });
+
+  it('can run xpathSelectorAll', async () => {
+    koaServer.get('/domextender-xpath-all', ctx => {
+      ctx.body = `
+        <body>
+          <h2>here 1</h2>
+          <h2>here 2</h2>
+          <h2>here 3</h2>
+        </body>
+      `;
+    });
+    const hero = await openBrowser(`/domextender-xpath-all`);
+
+    const xpathAll = await hero.xpathSelectorAll('//h2');
+
+    let counter = 0;
+    for (const entry of xpathAll) {
+      counter += 1;
+      await expect(entry.textContent).resolves.toBe(`here ${counter}`);
+    }
+  });
+
+  it('can find the focused field', async () => {
+    koaServer.get('/domextender-focused', ctx => {
+      ctx.body = `<body><input id="field" type="text"/></body>`;
+    });
+    const hero = await openBrowser(`/domextender-focused`);
+    await expect(hero.querySelector('#field').$hasFocus).resolves.toBe(false);
+    await expect(hero.querySelector('#field').$click()).resolves.toBe(undefined);
+    await expect(hero.querySelector('#field').$hasFocus).resolves.toBe(true);
+  });
+});
+
+async function openBrowser(path: string) {
+  const hero = new Hero();
+  Helpers.needsClosing.push(hero);
+  await hero.goto(`${koaServer.baseUrl}${path}`);
+  await hero.waitForPaintingStable();
+  return hero;
+}

--- a/interfaces/jsPathFnNames.ts
+++ b/interfaces/jsPathFnNames.ts
@@ -2,6 +2,7 @@ const getNodePointerFnName = '__getNodePointer__';
 const getClientRectFnName = '__getClientRect__';
 const getComputedVisibilityFnName = '__getComputedVisibility__';
 const getComputedStyleFnName = '__getComputedStyle__';
+const isFocusedFnName = '__isFocused__';
 const getNodeIdFnName = '__getNodeId__';
 
 export {
@@ -9,5 +10,6 @@ export {
   getClientRectFnName,
   getNodeIdFnName,
   getComputedStyleFnName,
+  isFocusedFnName,
   getComputedVisibilityFnName,
 };

--- a/puppet/index.ts
+++ b/puppet/index.ts
@@ -1,6 +1,7 @@
 import PuppetChrome from '@ulixee/hero-puppet-chrome';
 import { IBoundLog } from '@ulixee/commons/interfaces/ILog';
 import Log from '@ulixee/commons/lib/Logger';
+import { CanceledPromiseError } from '@ulixee/commons/interfaces/IPendingWaitEvent';
 import IPuppetLauncher from '@ulixee/hero-interfaces/IPuppetLauncher';
 import IPuppetBrowser from '@ulixee/hero-interfaces/IPuppetBrowser';
 import IBrowserEngine from '@ulixee/hero-interfaces/IBrowserEngine';
@@ -103,6 +104,7 @@ export default class Puppet extends TypedEventEmitter<{ close: void }> {
     proxy?: IProxyConnectionOptions,
     isIncognito = true,
   ): Promise<IPuppetContext> {
+    if (!this.isReady) throw new CanceledPromiseError('This Puppet has been shut down');
     await this.isReady.promise;
     if (!this.browser) {
       throw new Error('This Puppet instance has not had start() called on it');


### PR DESCRIPTION
This PR adds 3 dom extenders:
- $hasFocus - is a field focused
- $xpathSelector(path, ordered = false) - runs a singleNode xpath selector
- $xpathSelectorAll(path, ordered = false) - runs multiNode xpath selector

Also fixes an issue where interact wasn't working on xpath elements due to not evaluating the parameters to the xpath