### PR TITLE
feat: added extractorPromises into Client's CoreSession

### DIFF
--- a/client/lib/CoreSession.ts
+++ b/client/lib/CoreSession.ts
@@ -49,6 +49,7 @@ export default class CoreSession implements IJsPathEventTarget {
   private cliPrompt: ReadLine;
   private isClosing = false;
   private shutdownPromise: Promise<{ didKeepAlive: boolean; message?: string }>;
+  private extractorPromises: Promise<void>[] = [];
 
   constructor(
     sessionMeta: ISessionMeta & { sessionName: string },
@@ -150,6 +151,14 @@ export default class CoreSession implements IJsPathEventTarget {
       coreTab,
       prefetchedJsPaths,
     };
+  }
+
+  public addExtractorPromises(promise: Promise<void>): void {
+    this.extractorPromises.push(promise);
+  }
+
+  public getExtractorPromises(): Promise<void>[] {
+    return [...this.extractorPromises];
   }
 
   public async getCollectedResources(sessionId: string, name: string): Promise<IResourceMeta[]> {

--- a/client/lib/DomExtender.ts
+++ b/client/lib/DomExtender.ts
@@ -67,7 +67,7 @@ declare module 'awaited-dom/base/interfaces/official' {
   interface IHTMLCollection extends IBaseExtendNodeList {}
 }
 
-type INodeExtensionFns = Omit<IBaseExtendNode, '$isClickable' | '$isVisible' | '$exists', '$hasFocus'>;
+type INodeExtensionFns = Omit<IBaseExtendNode, '$isClickable' | '$isVisible' | '$exists' | '$hasFocus'>;
 const NodeExtensionFns: INodeExtensionFns = {
   async $click(verification: IElementInteractVerification = 'elementAtPath'): Promise<void> {
     const coreFrame = await getCoreFrame(this);

--- a/client/lib/Hero.ts
+++ b/client/lib/Hero.ts
@@ -65,6 +65,8 @@ import ConnectionToCore from '../connections/ConnectionToCore';
 import CoreSession from './CoreSession';
 import InternalProperties from './InternalProperties';
 import IResourceFilterProperties from '@ulixee/hero-interfaces/IResourceFilterProperties';
+import CoreTab from './CoreTab';
+import IResourceMeta from '@ulixee/hero-interfaces/IResourceMeta';
 
 export const DefaultOptions = {
   defaultBlockedResourceTypes: [BlockedResourceType.None],
@@ -108,6 +110,14 @@ export default class Hero extends AwaitedEventTarget<{
   #tabs: Tab[];
   #activeTab: Tab;
   #isClosingPromise: Promise<void>;
+
+  get [Symbol.for('@ulixee/internalState')](): {
+    coreSessionPromise: Promise<CoreSession>;
+  } {
+    return {
+      coreSessionPromise: this.#getCoreSessionOrReject(),
+    }
+  }
 
   constructor(createOptions: IHeroCreateOptions = {}) {
     super(() => {


### PR DESCRIPTION
This will allow Databox's DomExtensions to register multiple extract functions in Hero CoreSession, both for ChromeAlive to know when extractors are finished (this will require connecting it into core). It also allows DataboxInternal to track the same extract promises that DomExtensions added.