### PR TITLE
feat(client): add single resource search apis

### DIFF
--- a/client/interfaces/IWaitForResourceFilter.ts
+++ b/client/interfaces/IWaitForResourceFilter.ts
@@ -4,5 +4,5 @@ import Resource from '../lib/Resource';
 export default interface IWaitForResourceFilter {
   url?: string | RegExp;
   type?: IResourceType;
-  filterFn?: (resource: Resource, done: () => void) => Promise<boolean> | boolean;
+  filterFn?: (resource: Resource) => Promise<boolean> | boolean;
 }

--- a/client/interfaces/IWaitForResourcesFilter.ts
+++ b/client/interfaces/IWaitForResourcesFilter.ts
@@ -1,0 +1,6 @@
+import Resource from '../lib/Resource';
+import IWaitForResourceFilter from './IWaitForResourceFilter';
+
+export default interface IWaitForResourcesFilter extends Omit<IWaitForResourceFilter, 'filterFn'> {
+  filterFn?: (resource: Resource, done: () => void) => Promise<boolean> | boolean;
+}

--- a/client/lib/CoreTab.ts
+++ b/client/lib/CoreTab.ts
@@ -148,7 +148,7 @@ export default class CoreTab implements IJsPathEventTarget {
     commandFn: () => Promise<T>,
     exitState: IDomState | DomState | IDomStateAllFn,
     callsitePath: ISourceCodeLocation[],
-    options?: IFlowCommandOptions
+    options?: IFlowCommandOptions,
   ): Promise<T> {
     if (typeof exitState === 'function') {
       exitState = { all: exitState };
@@ -258,6 +258,13 @@ export default class CoreTab implements IJsPathEventTarget {
     return await this.commandQueue.run('Tab.findResource', filter, options);
   }
 
+  public async findResources(
+    filter: IResourceFilterProperties,
+    options?: { sinceCommandId?: number },
+  ): Promise<IResourceMeta[]> {
+    return await this.commandQueue.run('Tab.findResources', filter, options);
+  }
+
   public async reload(options: { timeoutMs?: number }): Promise<IResourceMeta> {
     return await this.commandQueue.run('Tab.reload', options);
   }
@@ -274,11 +281,11 @@ export default class CoreTab implements IJsPathEventTarget {
     return await this.commandQueue.run('Tab.waitForFileChooser', options);
   }
 
-  public async waitForResource(
+  public async waitForResources(
     filter: Pick<IWaitForResourceFilter, 'url' | 'type'>,
     opts: IWaitForResourceOptions,
   ): Promise<IResourceMeta[]> {
-    return await this.commandQueue.run('Tab.waitForResource', filter, opts);
+    return await this.commandQueue.run('Tab.waitForResources', filter, opts);
   }
 
   public async waitForMillis(millis: number): Promise<void> {

--- a/client/lib/Hero.ts
+++ b/client/lib/Hero.ts
@@ -62,6 +62,7 @@ import { InternalPropertiesSymbol, scriptInstance } from './internal';
 import IResourceFilterProperties from '@ulixee/hero-interfaces/IResourceFilterProperties';
 import './DomExtender';
 import IFlowCommandOptions from '@ulixee/hero-interfaces/IFlowCommandOptions';
+import IWaitForResourcesFilter from '../interfaces/IWaitForResourcesFilter';
 
 export const DefaultOptions = {
   defaultBlockedResourceTypes: [BlockedResourceType.None],
@@ -262,6 +263,13 @@ export default class Hero extends AwaitedEventTarget<{
     return await this.activeTab.findResource(filter, options);
   }
 
+  public async findResources(
+    filter: IResourceFilterProperties,
+    options?: { sinceCommandId: number },
+  ): Promise<Resource[]> {
+    return await this.activeTab.findResources(filter, options);
+  }
+
   public async focusTab(tab: Tab): Promise<void> {
     const coreTab = await getCoreTab(tab);
     await coreTab.focusTab();
@@ -439,8 +447,15 @@ export default class Hero extends AwaitedEventTarget<{
   public waitForResource(
     filter: IWaitForResourceFilter,
     options?: IWaitForResourceOptions,
-  ): Promise<(Resource | WebsocketResource)[]> {
+  ): Promise<Resource | WebsocketResource> {
     return this.activeTab.waitForResource(filter, options);
+  }
+
+  public waitForResources(
+    filter: IWaitForResourcesFilter,
+    options?: IWaitForResourceOptions,
+  ): Promise<(Resource | WebsocketResource)[]> {
+    return this.activeTab.waitForResources(filter, options);
   }
 
   public waitForElement(
@@ -476,7 +491,7 @@ export default class Hero extends AwaitedEventTarget<{
   public async flowCommand(
     commandFn: () => Promise<void>,
     exitState?: IDomState | DomState | IDomStateAllFn,
-    options?: IFlowCommandOptions
+    options?: IFlowCommandOptions,
   ): Promise<void> {
     return await this.activeTab.flowCommand(commandFn, exitState, options);
   }

--- a/client/lib/Tab.ts
+++ b/client/lib/Tab.ts
@@ -39,6 +39,7 @@ import DomState from './DomState';
 import IDomState, { IDomStateAllFn } from '@ulixee/hero-interfaces/IDomState';
 import { InternalPropertiesSymbol, scriptInstance } from './internal';
 import IFlowCommandOptions from '@ulixee/hero-interfaces/IFlowCommandOptions';
+import IWaitForResourcesFilter from '../interfaces/IWaitForResourcesFilter';
 
 const awaitedPathState = StateMachine<
   any,
@@ -165,6 +166,13 @@ export default class Tab extends AwaitedEventTarget<IEventType> {
     return Resource.findLatest(this, filter, options);
   }
 
+  public findResources(
+    filter: IResourceFilterProperties,
+    options?: { sinceCommandId: number },
+  ): Promise<Resource[]> {
+    return Resource.findAll(this, filter, options);
+  }
+
   public async fetch(request: Request | string, init?: IRequestInit): Promise<Response> {
     return await this.mainFrameEnvironment.fetch(request, init);
   }
@@ -289,7 +297,7 @@ export default class Tab extends AwaitedEventTarget<IEventType> {
   public async flowCommand<T = void>(
     commandFn: () => Promise<T>,
     exitState?: IDomState | DomState | IDomStateAllFn,
-    options?: IFlowCommandOptions
+    options?: IFlowCommandOptions,
   ): Promise<T> {
     const callsitePath = scriptInstance.getScriptCallsite();
 
@@ -300,8 +308,15 @@ export default class Tab extends AwaitedEventTarget<IEventType> {
   public waitForResource(
     filter: IWaitForResourceFilter,
     options?: IWaitForResourceOptions,
+  ): Promise<Resource | WebsocketResource> {
+    return Resource.waitForOne(this, filter, options);
+  }
+
+  public waitForResources(
+    filter: IWaitForResourcesFilter,
+    options?: IWaitForResourceOptions,
   ): Promise<(Resource | WebsocketResource)[]> {
-    return Resource.waitFor(this, filter, options);
+    return Resource.waitForMany(this, filter, options);
   }
 
   public async waitForElement(

--- a/core/lib/Resources.ts
+++ b/core/lib/Resources.ts
@@ -64,6 +64,7 @@ export default class Resources {
   }
 
   public recordSeen(resource: IResourceMeta, atCommandId: number): void {
+    resource.seenAtCommandId = atCommandId;
     this.get(resource.id).seenAtCommandId = atCommandId;
   }
 

--- a/core/test/resources.test.ts
+++ b/core/test/resources.test.ts
@@ -46,7 +46,7 @@ test('loads http2 resources', async () => {
   await tab.goto(server.url);
   await tab.waitForLoad('DomContentLoaded');
 
-  const resources = await tab.waitForResource({ url: /.*\/img.png/ });
+  const resources = await tab.waitForResources({ url: /.*\/img.png/ });
   expect(resources).toHaveLength(1);
   expect(resources[0].type).toBe('Image');
   await session.close();

--- a/fullstack/test/tab.test.ts
+++ b/fullstack/test/tab.test.ts
@@ -105,7 +105,7 @@ describe('Multi-tab scenarios', () => {
     await hero.click(hero.document.querySelector('a'));
 
     const tab1 = hero.activeTab;
-    const page1Logos = await tab1.waitForResource({
+    const page1Logos = await tab1.waitForResources({
       url: '/logo.png',
     });
     expect(page1Logos).toHaveLength(2);
@@ -120,7 +120,7 @@ describe('Multi-tab scenarios', () => {
     const tabs = await hero.tabs;
     expect(tabs).toHaveLength(2);
     const tab2 = tabs[1];
-    const page2Logos = await tab2.waitForResource({
+    const page2Logos = await tab2.waitForResources({
       url: '/logo.png?page=page2',
     });
     expect(page2Logos).toHaveLength(1);

--- a/fullstack/test/websocket.test.ts
+++ b/fullstack/test/websocket.test.ts
@@ -73,10 +73,9 @@ describe('Websocket tests', () => {
 
     expect(upgradeSpy).toHaveBeenCalledTimes(1);
 
-    const resources = await hero.waitForResource({ type: 'Websocket' });
-    expect(resources).toHaveLength(1);
+    const resource = await hero.waitForResource({ type: 'Websocket' });
 
-    const [wsResource] = resources as WebsocketResource[];
+    const wsResource = resource as WebsocketResource;
 
     const broadcast = createPromise();
     let messagesCtr = 0;


### PR DESCRIPTION
It became apparent when writing out example docs in Databox that we need both singular and plural resource apis. Otherwise you CAN'T do a findResource and actually find all of them. And once you have both `findResource` and `findResources`, it just doesn't make sense to have a method called `waitForResource` that returns multiple.

This PR changes our resource APIs to the following:
1. waitForResource is renamed to waitForResources
2. waitForResource is now a singular resource lookup. There is no "done" function required if you use a filter function. The function escapes when you return.
3. findResource returns a single resource since the page loaded (http request, not in-page load)
4. findResources finds many resources since the page loaded (http request, not in-page load) 