### PR TITLE
Adjust FlowCommand syntax

### DIFF
--- a/client/lib/Hero.ts
+++ b/client/lib/Hero.ts
@@ -475,10 +475,9 @@ export default class Hero extends AwaitedEventTarget<{
 
   public async flowCommand(
     commandFn: () => Promise<void>,
-    exitState?: IDomState | DomState | IDomStateAllFn,
-    options?: IFlowCommandOptions
+    optionsOrExitState?: IDomStateAllFn | IFlowCommandOptions,
   ): Promise<void> {
-    return await this.activeTab.flowCommand(commandFn, exitState, options);
+    return await this.activeTab.flowCommand(commandFn, optionsOrExitState);
   }
 
   public async registerFlowHandler(

--- a/client/lib/Tab.ts
+++ b/client/lib/Tab.ts
@@ -288,12 +288,26 @@ export default class Tab extends AwaitedEventTarget<IEventType> {
 
   public async flowCommand<T = void>(
     commandFn: () => Promise<T>,
-    exitState?: IDomState | DomState | IDomStateAllFn,
-    options?: IFlowCommandOptions
+    optionsOrExitState?: IDomStateAllFn | IFlowCommandOptions,
   ): Promise<T> {
     const callsitePath = scriptInstance.getScriptCallsite();
 
     const coreTab = await this.#coreTabPromise;
+
+    let exitState: IDomState | IDomStateAllFn;
+    let options: IFlowCommandOptions;
+    if (optionsOrExitState) {
+      if (typeof optionsOrExitState === 'function') exitState = { all: optionsOrExitState };
+      else {
+        if ('maxRetries' in optionsOrExitState) {
+          options = { maxRetries: optionsOrExitState.maxRetries };
+        }
+        if ('exitState' in optionsOrExitState) {
+          exitState = optionsOrExitState.exitState;
+        }
+      }
+    }
+
     return await coreTab.runFlowCommand(commandFn, exitState, callsitePath, options);
   }
 

--- a/interfaces/IFlowCommandOptions.ts
+++ b/interfaces/IFlowCommandOptions.ts
@@ -1,3 +1,6 @@
+import IDomState, { IDomStateAllFn } from './IDomState';
+
 export default interface IFlowCommandOptions {
-  maxRetries: number;
+  maxRetries?: number;
+  exitState?: IDomState | IDomStateAllFn;
 }


### PR DESCRIPTION
FlowCommands now take only 2 parameters. You can either provide 2 parameters where the exitState is a callback:
```js
await hero.flowCommand(async () => {
  const field = await hero.querySelector('#text').$waitForVisible();
  await field.$type('test');
}, (assert) => {
    assert(hero.querySelector('#text').value, 'test');
});
```

or 2 parameters where the second parameter is an object with options:
```js
await hero.flowCommand(async () => {
  const field = await hero.querySelector('#text').$waitForVisible();
  await field.$type('test');
 }, {
  maxRetries: 2,
  exitState(assert) {
    assert(hero.querySelector('#text').value, 'test');
  },
});
```