### PR TITLE
Tabs support

### DIFF
--- a/core/lib/Session.ts
+++ b/core/lib/Session.ts
@@ -7,7 +7,7 @@ import RequestSession, {
   IResourceStateChangeEvent,
   ISocketEvent,
 } from '@ulixee/hero-mitm/handlers/RequestSession';
-import IPuppetContext, { IPuppetContextEvents } from '@ulixee/hero-interfaces/IPuppetContext';
+import IPuppetContext, { IPuppetContextEvents, IPuppetPageOptions } from '@ulixee/hero-interfaces/IPuppetContext';
 import IUserProfile from '@ulixee/hero-interfaces/IUserProfile';
 import { IPuppetPage } from '@ulixee/hero-interfaces/IPuppetPage';
 import IBrowserEngine from '@ulixee/hero-interfaces/IBrowserEngine';
@@ -55,8 +55,7 @@ export default class Session
     'all-tabs-closed': void;
     output: { changes: IOutputChangeRecord[] };
   }>
-  implements ICommandableTarget, IRemoteEventListener
-{
+  implements ICommandableTarget, IRemoteEventListener {
   private static readonly byId: { [id: string]: Session } = {};
 
   public readonly id: string;
@@ -393,7 +392,7 @@ export default class Session
   }
 
   public async createTab(): Promise<Tab> {
-    const page = await this.newPage();
+    const page = await this.newPage({ groupName: 'session' });
 
     // if first tab, install session storage
     if (!this.hasLoadedUserProfile && this.userProfile?.storage) {
@@ -677,9 +676,9 @@ export default class Session
     return tab;
   }
 
-  private async newPage(): Promise<IPuppetPage> {
+  private async newPage(options?: IPuppetPageOptions): Promise<IPuppetPage> {
     if (this._isClosing) throw new Error('Cannot create tab, shutting down');
-    return await this.browserContext.newPage();
+    return await this.browserContext.newPage(options);
   }
 
   private recordLog(entry: ILogEntry): void {

--- a/interfaces/IPuppetContext.ts
+++ b/interfaces/IPuppetContext.ts
@@ -29,7 +29,8 @@ export default interface IPuppetContext extends ITypedEventEmitter<IPuppetContex
 }
 
 export interface IPuppetPageOptions {
-  runPageScripts: boolean;
+  groupName?: string;
+  runPageScripts?: boolean;
   enableDomStorageTracker?: boolean;
   triggerPopupOnPageId?: string;
 }

--- a/interfaces/IPuppetPage.ts
+++ b/interfaces/IPuppetPage.ts
@@ -22,7 +22,8 @@ export interface IPuppetPage extends ITypedEventEmitter<IPuppetPageEvents> {
   mainFrame: IPuppetFrame;
   domStorageTracker: IPuppetDomStorageTracker;
   opener?: IPuppetPage;
-
+  groupName: string;
+  
   isClosed: boolean;
   navigate(url: string, options?: { referrer?: string }): Promise<{ loaderId: string }>;
   dismissDialog(accept: boolean, promptText?: string): Promise<void>;

--- a/puppet-chrome/lib/Page.ts
+++ b/puppet-chrome/lib/Page.ts
@@ -54,6 +54,7 @@ export class Page extends TypedEventEmitter<IPuppetPageEvents> implements IPuppe
   public networkManager: NetworkManager;
   public framesManager: FramesManager;
   public domStorageTracker: DomStorageTracker;
+  public groupName: string;
 
   public popupInitializeFn?: (
     page: IPuppetPage,
@@ -97,6 +98,7 @@ export class Page extends TypedEventEmitter<IPuppetPageEvents> implements IPuppe
   ) {
     super();
 
+    this.groupName = pageOptions?.groupName;
     this.logger = logger.createChild(module, {
       targetId,
     });

--- a/timetravel/player/TimetravelPlayer.ts
+++ b/timetravel/player/TimetravelPlayer.ts
@@ -16,8 +16,6 @@ import CorePlugins from '@ulixee/hero-core/lib/CorePlugins';
 const { log } = Log(module);
 
 export default class TimetravelPlayer extends TypedEventEmitter<{
-  'all-tabs-closed': void;
-  'timetravel-to-end': void;
   'new-tick-command': {
     commandId: number;
     paintIndex: number;
@@ -26,7 +24,8 @@ export default class TimetravelPlayer extends TypedEventEmitter<{
     paintIndex: number;
     documentLoadPaintIndex: number;
   };
-  open: void;
+  'tab-opened': void;
+  'all-tabs-closed': void;
 }> {
   public get activeCommandId(): number {
     if (this.isOpen) {
@@ -123,9 +122,7 @@ export default class TimetravelPlayer extends TypedEventEmitter<{
      *       If 1 tab is active, switch to it, otherwise, need to show the multi-timeline view and pick one tab to show
      */
     const tab = this.activeTab;
-
     const startTick = tab.currentTick;
-    const startedOpen = tab.isOpen;
     await this.openTab(tab);
     if (sessionOffsetPercent !== undefined) {
       await tab.setTimelineOffset(sessionOffsetPercent);
@@ -133,9 +130,6 @@ export default class TimetravelPlayer extends TypedEventEmitter<{
       await tab.loadEndState();
     }
 
-    if (startedOpen && sessionOffsetPercent === 100) {
-      this.emit('timetravel-to-end');
-    }
     if (tab.currentTick && tab.currentTick.commandId !== startTick?.commandId) {
       this.emit('new-tick-command', {
         commandId: tab.currentTick.commandId,
@@ -284,7 +278,7 @@ export default class TimetravelPlayer extends TypedEventEmitter<{
   }
 
   private onTabOpen(): void {
-    this.emit('open');
+    this.emit('tab-opened');
   }
 
   private async getResourceDetails(resourceId: number): Promise<ISessionResourceDetails> {


### PR DESCRIPTION
Some changes needed for the `tabs` ulixee PR:

- PuppetPage instances now have an optional groupName property. This is used in ChromeAlive's SessionObserver to filter only the Live pages/tabs.
- Removed some unneeded events from TimetravelPlayer. SessionObserver's integration with extension tabs has changed substantially.