### PR TITLE
On devtools detached

### DIFF
--- a/core/lib/CorePlugins.ts
+++ b/core/lib/CorePlugins.ts
@@ -308,6 +308,14 @@ export default class CorePlugins implements ICorePlugins {
     );
   }
 
+  public async onDevtoolsPanelDetached(devtoolsSession: IDevtoolsSession): Promise<any> {
+    await Promise.all(
+      this.instances
+        .filter(p => p.onDevtoolsPanelDetached)
+        .map(p => p.onDevtoolsPanelDetached(devtoolsSession)),
+    );
+  }
+
   public async onServiceWorkerAttached(
     devtoolsSession: IDevtoolsSession,
     event: Protocol.Target.AttachedToTargetEvent,

--- a/interfaces/ICorePlugin.ts
+++ b/interfaces/ICorePlugin.ts
@@ -37,6 +37,7 @@ export interface ICorePluginClass {
 export interface ICorePluginMethods {
   onClientCommand?(meta: IOnClientCommandMeta, ...args: any[]): Promise<any>;
   onDevtoolsPanelAttached?(devtoolsSession: IDevtoolsSession): Promise<any>;
+  onDevtoolsPanelDetached?(devtoolsSession: IDevtoolsSession): Promise<any>;
   onServiceWorkerAttached?(
     devtoolsSession: IDevtoolsSession,
     event: Protocol.Target.AttachedToTargetEvent,

--- a/interfaces/package.json
+++ b/interfaces/package.json
@@ -5,6 +5,6 @@
   "dependencies": {
     "awaited-dom": "1.3.2",
     "@ulixee/commons": "1.5.10",
-    "devtools-protocol": "^0.0.799653"
+    "devtools-protocol": "^0.0.981744"
   }
 }

--- a/mitm/package.json
+++ b/mitm/package.json
@@ -8,7 +8,7 @@
     "@ulixee/hero-interfaces": "1.5.4",
     "@ulixee/hero-mitm-socket": "1.5.4",
     "better-sqlite3": "^7.5.0",
-    "devtools-protocol": "^0.0.799653",
+    "devtools-protocol": "^0.0.981744",
     "dns-packet": "^5.2.4",
     "moment": "^2.24.1"
   },

--- a/puppet-chrome/lib/Browser.ts
+++ b/puppet-chrome/lib/Browser.ts
@@ -156,10 +156,11 @@ export class Browser extends TypedEventEmitter<IBrowserEvents> implements IPuppe
 
     if (targetInfo.type === 'other' && targetInfo.url.startsWith('devtools://devtools')) {
       const devtoolsSession = this.connection.getSession(sessionId);
-      if (this.onDevtoolsPanelAttached)
+      if (this.onDevtoolsPanelAttached) {
         this.onDevtoolsPanelAttached(devtoolsSession).catch(() => null);
+      }
       const context = this.getBrowserContext(targetInfo.browserContextId);
-      context?.plugins.onDevtoolsPanelAttached(devtoolsSession).catch(() => null);
+      context?.onDevtoolsPanelAttached(devtoolsSession, targetInfo);
       return;
     }
 
@@ -203,8 +204,8 @@ export class Browser extends TypedEventEmitter<IBrowserEvents> implements IPuppe
     }
   }
 
-  private onDetachedFromTarget(payload: Protocol.Target.DetachedFromTargetEvent): void {
-    const targetId = payload.targetId;
+  private onDetachedFromTarget(event: Protocol.Target.DetachedFromTargetEvent): void {
+    const targetId = event.targetId;
     for (const [, context] of this.browserContextsById) {
       context.onPageDetached(targetId);
     }

--- a/puppet-chrome/lib/BrowserContext.ts
+++ b/puppet-chrome/lib/BrowserContext.ts
@@ -36,6 +36,7 @@ export class BrowserContext
 
   public workersById = new Map<string, IPuppetWorker>();
   public pagesById = new Map<string, Page>();
+  public devtoolsSessionsById = new Map<string, DevtoolsSession>();
   public plugins: ICorePlugins;
   public proxy: IProxyConnectionOptions;
   public domStorage: IDomStorage;
@@ -170,7 +171,22 @@ export class BrowserContext
     if (page) {
       this.pagesById.delete(targetId);
       page.didClose();
+      return;
     }
+
+    const devtoolsSession = this.devtoolsSessionsById.get(targetId);
+    if (devtoolsSession) {
+      this.onDevtoolsPanelDetached(devtoolsSession);
+    }
+  }
+
+  onDevtoolsPanelAttached(devtoolsSession: DevtoolsSession, targetInfo: TargetInfo): void {
+    this.devtoolsSessionsById.set(targetInfo.targetId, devtoolsSession);
+    this.plugins.onDevtoolsPanelAttached(devtoolsSession).catch(() => null);
+  }
+
+  onDevtoolsPanelDetached(devtoolsSession: DevtoolsSession): void {
+    this.plugins.onDevtoolsPanelDetached(devtoolsSession).catch(() => null);
   }
 
   async onSharedWorkerAttached(

--- a/puppet-chrome/lib/Page.ts
+++ b/puppet-chrome/lib/Page.ts
@@ -280,7 +280,6 @@ export class Page extends TypedEventEmitter<IPuppetPageEvents> implements IPuppe
     const layoutMetrics = await this.devtoolsSession.send('Page.getLayoutMetrics');
 
     const { scale, pageX, pageY }  = layoutMetrics.visualViewport;
-    // @ts-expect-error -- Chrome 98 added css content size, which is scaled correctly
     const contentSize = layoutMetrics.cssContentSize ?? layoutMetrics.contentSize;
 
     let resizeAfterScreenshot: SetDeviceMetricsOverrideRequest;

--- a/puppet-chrome/package.json
+++ b/puppet-chrome/package.json
@@ -5,6 +5,6 @@
   "dependencies": {
     "@ulixee/commons": "1.5.10",
     "@ulixee/hero-interfaces": "1.5.4",
-    "devtools-protocol": "^0.0.799653"
+    "devtools-protocol": "^0.0.981744"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3289,6 +3289,11 @@ devtools-protocol@^0.0.799653:
   resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.799653.tgz#86fc95ce5bf4fdf4b77a58047ba9d2301078f119"
   integrity sha512-t1CcaZbvm8pOlikqrsIM9GOa7Ipp07+4h/q9u0JXBWjPCjHdBl9KkddX87Vv9vBHoBGtwV79sYQNGnQM6iS5gg==
 
+devtools-protocol@^0.0.981744:
+  version "0.0.981744"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.981744.tgz#9960da0370284577d46c28979a0b32651022bacf"
+  integrity sha512-0cuGS8+jhR67Fy7qG3i3Pc7Aw494sb9yG9QgpG97SFVWwolgYjlhJg7n+UaHxOQT30d1TYu/EYe9k01ivLErIg==
+
 dezalgo@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"


### PR DESCRIPTION
- Plugins can now use onDevtoolsPanelDetached in order to cleanup from onDevtoolsPanelAttached.
- Upgrafded devtools-protocol module