### PR TITLE
fix(timetravel): timetravel creating dup contexts

### DIFF
--- a/core/lib/InjectedScripts.ts
+++ b/core/lib/InjectedScripts.ts
@@ -83,8 +83,8 @@ export default class InjectedScripts {
     ]);
   }
 
-  public static installInteractionScript(puppetPage: IPuppetPage): Promise<{ identifier: string }> {
-    return puppetPage.addNewDocumentScript(showInteractionScript, true);
+  public static installInteractionScript(puppetPage: IPuppetPage, isolatedFromWebPage = true): Promise<{ identifier: string }> {
+    return puppetPage.addNewDocumentScript(showInteractionScript, isolatedFromWebPage);
   }
 
   public static async installDomStorageRestore(

--- a/timetravel/injected-scripts/domReplayer.ts
+++ b/timetravel/injected-scripts/domReplayer.ts
@@ -87,6 +87,7 @@ class DomReplayer {
 
     this.loadedIndex = index;
     if (window.repositionInteractElements) window.repositionInteractElements();
+    console.clear();
   }
 
   private applyDomChanges(changeEvents: IFrontendDomChangeEvent[], isReverse = false): void {

--- a/timetravel/lib/MirrorNetwork.ts
+++ b/timetravel/lib/MirrorNetwork.ts
@@ -59,7 +59,10 @@ export default class MirrorNetwork {
       return {
         requestId: request.requestId,
         responseCode: 200,
-        responseHeaders: [{ name: 'Content-Type', value: 'text/html; charset=utf-8' }],
+        responseHeaders: [
+          { name: 'Content-Type', value: 'text/html; charset=utf-8' },
+          { name: 'Content-Security-Policy', value: "script-src 'nonce-hero-timetravel'" },
+        ],
         body: Buffer.from(`${doctype}<html><head></head><body></body></html>`).toString('base64'),
       };
     }


### PR DESCRIPTION
When you access ContentWindow or Parent from an isolated Chrome context, it seems to create additional isolated contexts. This creates a situation where in TimeTravel, we're ending up with many HeroWorlds, and then we don't know which one has pre-installed the domReplayer script and other things. This issue does not seem to exist when things are run in the default context, however, if you "disable" javascript, it also disables javascript in the main context. I was able to workaround this by re-enabling javascript in the default context, but adding a ContentSecurityPolicy that says only scripts with the nonce "hero-timetravel" should be allowed - ie, no scripts. The main downside is this creates logging about blocked content security policies. However... it fixes the breaking history. I'm not sure how to find a better solution. I think we should likely log something in the Chromium project about the broken contexts, but this is the best option we've got for now.