### PR TITLE
fix(core): restore user profiles in frames

### DIFF
--- a/core/injected-scripts/domStorage.ts
+++ b/core/injected-scripts/domStorage.ts
@@ -10,15 +10,6 @@ function dumpStorage(storage: Storage) {
   return store;
 }
 
-function restoreStorage(storage: Storage, store: IStorageEntry[]) {
-  // only run on empty!
-  if (storage.length) return;
-  if (!store || !store.length) return;
-  for (const [key, value] of store) {
-    storage.setItem(key, value);
-  }
-}
-
 async function exportIndexedDbs(dbNames: string[]) {
   if (!dbNames || !dbNames.length) return [];
 
@@ -88,70 +79,6 @@ async function readStoreData(store: IDBObjectStore) {
   });
   return data;
 }
-
-async function restoreIndexedDb(restoreDBs: IIndexedDB[]) {
-  if (!restoreDBs || !restoreDBs.length) return;
-
-  for (const restoreDB of restoreDBs) {
-    await new Promise<void>((resolve, reject) => {
-      const openDBRequest = indexedDB.open(restoreDB.name, restoreDB.version);
-      // only run changes when the db doesn't already exist
-      openDBRequest.onupgradeneeded = event => {
-        const request = event.target as IDBRequest<IDBDatabase>;
-        const db = request.result;
-        for (const objectStoreToRestore of restoreDB.objectStores) {
-          const objectStore = db.createObjectStore(objectStoreToRestore.name, {
-            autoIncrement: objectStoreToRestore.autoIncrement,
-            keyPath: objectStoreToRestore.keyPath,
-          });
-
-          for (const restoreIndex of objectStoreToRestore.indexes) {
-            objectStore.createIndex(restoreIndex.name, restoreIndex.keyPath, {
-              multiEntry: restoreIndex.multiEntry,
-              unique: restoreIndex.unique,
-            });
-          }
-        }
-      };
-      openDBRequest.onsuccess = async event => {
-        const request = event.target as IDBRequest<IDBDatabase>;
-        try {
-          await restoreData(request.result, restoreDB);
-          resolve();
-        } catch (err) {
-          reject(err);
-        }
-      };
-      openDBRequest.onerror = reject;
-    });
-  }
-}
-
-async function restoreData(db: IDBDatabase, restoreDB: IIndexedDB) {
-  for (const objectStoreToRestore of restoreDB.objectStores) {
-    const data = restoreDB.data[objectStoreToRestore.name];
-    if (!data || !data.length) continue;
-    const insertStore = db
-      .transaction(objectStoreToRestore.name, 'readwrite')
-      .objectStore(objectStoreToRestore.name);
-    for (const record of data) {
-      const { key, value } = TypeSerializer.parse(record);
-      insertStore.add(value, key);
-    }
-    await new Promise((resolve, reject) => {
-      insertStore.transaction.oncomplete = resolve;
-      insertStore.transaction.onerror = reject;
-    });
-  }
-}
-
-// @ts-ignore
-window.restoreUserStorage = async (data: IDomStorageForOrigin) => {
-  if (!data) return;
-  restoreStorage(localStorage, data.localStorage);
-  restoreStorage(sessionStorage, data.sessionStorage);
-  await restoreIndexedDb(data.indexedDB);
-};
 
 // @ts-ignore
 window.exportDomStorage = async (dbNames: string[]) => {

--- a/core/injected-scripts/indexedDbRestore.ts
+++ b/core/injected-scripts/indexedDbRestore.ts
@@ -1,0 +1,60 @@
+import { IIndexedDB } from '@ulixee/hero-interfaces/IIndexedDB';
+
+async function restoreIndexedDb(restoreDBs: IIndexedDB[]) {
+  if (!restoreDBs || !restoreDBs.length) return;
+
+  for (const restoreDB of restoreDBs) {
+    await new Promise<void>((resolve, reject) => {
+      const openDBRequest = indexedDB.open(restoreDB.name, restoreDB.version);
+      // only run changes when the db doesn't already exist
+      openDBRequest.onupgradeneeded = event => {
+        const request = event.target as IDBRequest<IDBDatabase>;
+        const db = request.result;
+        for (const objectStoreToRestore of restoreDB.objectStores) {
+          const objectStore = db.createObjectStore(objectStoreToRestore.name, {
+            autoIncrement: objectStoreToRestore.autoIncrement,
+            keyPath: objectStoreToRestore.keyPath,
+          });
+
+          for (const restoreIndex of objectStoreToRestore.indexes) {
+            objectStore.createIndex(restoreIndex.name, restoreIndex.keyPath, {
+              multiEntry: restoreIndex.multiEntry,
+              unique: restoreIndex.unique,
+            });
+          }
+        }
+      };
+      openDBRequest.onsuccess = async event => {
+        const request = event.target as IDBRequest<IDBDatabase>;
+        try {
+          await restoreData(request.result, restoreDB);
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      };
+      openDBRequest.onerror = reject;
+    });
+  }
+}
+
+async function restoreData(db: IDBDatabase, restoreDB: IIndexedDB) {
+  for (const objectStoreToRestore of restoreDB.objectStores) {
+    const data = restoreDB.data[objectStoreToRestore.name];
+    if (!data || !data.length) continue;
+    const insertStore = db
+      .transaction(objectStoreToRestore.name, 'readwrite')
+      .objectStore(objectStoreToRestore.name);
+    for (const record of data) {
+      const { key, value } = TypeSerializer.parse(record);
+      insertStore.add(value, key);
+    }
+    await new Promise((resolve, reject) => {
+      insertStore.transaction.oncomplete = resolve;
+      insertStore.transaction.onerror = reject;
+    });
+  }
+}
+
+// @ts-ignore
+window.restoreUserStorage = restoreIndexedDb;

--- a/core/lib/InjectedScripts.ts
+++ b/core/lib/InjectedScripts.ts
@@ -89,14 +89,12 @@ export default class InjectedScripts {
     return puppetPage.addNewDocumentScript(showInteractionScript, true);
   }
 
-  public static getIndexedDbStorageRestoreScript(restoreDBs: IIndexedDB[]): string {
+  public static getIndexedDbStorageRestoreScript(): string {
     return `(function restoreIndexedDB(dbs) {
 const exports = {}; // workaround for ts adding an exports variable
 ${stringifiedTypeSerializerClass};
 
 ${pageScripts.indexedDbRestore};
-restoreUserStorage(dbs);
-})(${JSON.stringify(restoreDBs)});`;
-
+})();`;
   }
 }

--- a/core/lib/InjectedScripts.ts
+++ b/core/lib/InjectedScripts.ts
@@ -1,9 +1,11 @@
 import * as fs from 'fs';
 import { IPuppetPage } from '@ulixee/hero-interfaces/IPuppetPage';
 import { stringifiedTypeSerializerClass } from '@ulixee/commons/lib/TypeSerializer';
+import { IIndexedDB } from '@ulixee/hero-interfaces/IIndexedDB';
 
 const pageScripts = {
   domStorage: fs.readFileSync(`${__dirname}/../injected-scripts/domStorage.js`, 'utf8'),
+  indexedDbRestore: fs.readFileSync(`${__dirname}/../injected-scripts/indexedDbRestore.js`, 'utf8'),
   interactReplayer: fs.readFileSync(`${__dirname}/../injected-scripts/interactReplayer.js`, 'utf8'),
   NodeTracker: fs.readFileSync(`${__dirname}/../injected-scripts/NodeTracker.js`, 'utf8'),
   DomAssertions: fs.readFileSync(`${__dirname}/../injected-scripts/DomAssertions.js`, 'utf8'),
@@ -87,17 +89,14 @@ export default class InjectedScripts {
     return puppetPage.addNewDocumentScript(showInteractionScript, true);
   }
 
-  public static async installDomStorageRestore(
-    puppetPage: IPuppetPage,
-  ): Promise<{ identifier: string }> {
-    return await puppetPage.addNewDocumentScript(
-      `(function restoreDomStorage() {
+  public static getIndexedDbStorageRestoreScript(restoreDBs: IIndexedDB[]): string {
+    return `(function restoreIndexedDB(dbs) {
 const exports = {}; // workaround for ts adding an exports variable
 ${stringifiedTypeSerializerClass};
 
-${pageScripts.domStorage};
-})();`,
-      true,
-    );
+${pageScripts.indexedDbRestore};
+restoreUserStorage(dbs);
+})(${JSON.stringify(restoreDBs)});`;
+
   }
 }

--- a/core/lib/Resources.ts
+++ b/core/lib/Resources.ts
@@ -256,6 +256,13 @@ export default class Resources {
     this.record(null, request, false);
   }
 
+  public resolveBrowserRequest(mitmResource: IHttpResourceLoadDetails): void {
+    const pendingBrowserRequest = this.findMatchingRequest(mitmResource, 'noMitmResourceId');
+    if (pendingBrowserRequest && !pendingBrowserRequest.browserRequestedPromise.isResolved) {
+      pendingBrowserRequest.browserRequestedPromise.resolve();
+    }
+  }
+
   public determineResourceType(mitmResource: IHttpResourceLoadDetails): void {
     const pendingBrowserRequest =
       this.findMatchingRequest(mitmResource, 'noMitmResourceId') ??

--- a/core/lib/Session.ts
+++ b/core/lib/Session.ts
@@ -399,7 +399,7 @@ export default class Session
     this.browserContext = context;
     this.events.on(context as any, 'devtools-message', this.onDevtoolsMessage.bind(this));
     if (this.userProfile) {
-      await UserProfile.install(this);
+      await UserProfile.installCookies(this);
     }
 
     context.defaultPageInitializationFn = page =>
@@ -428,7 +428,7 @@ export default class Session
 
     // if first tab, install session storage
     if (!this.hasLoadedUserProfile && this.userProfile?.storage) {
-      await UserProfile.installSessionStorage(this, page);
+      await UserProfile.installStorage(this, page);
       this.hasLoadedUserProfile = true;
     }
 
@@ -480,7 +480,7 @@ export default class Session
       }
       // after we're all the way cleared, install user profile again
       if (this.userProfile) {
-        await UserProfile.install(this);
+        await UserProfile.installCookies(this);
       }
       // pop a new tab on
       await this.createTab();

--- a/core/lib/UserProfile.ts
+++ b/core/lib/UserProfile.ts
@@ -53,10 +53,9 @@ export default class UserProfile {
     } as IUserProfile;
   }
 
-  public static async install(session: Session): Promise<UserProfile> {
+  public static async installCookies(session: Session): Promise<UserProfile> {
     const { userProfile } = session;
     assert(userProfile, 'UserProfile exists');
-    const sessionId = session.id;
 
     const { storage, cookies } = userProfile;
     const origins = Object.keys(storage ?? {});
@@ -66,90 +65,103 @@ export default class UserProfile {
       return this;
     }
 
-    const parentLogId = log.info('UserProfile.install', {
-      sessionId,
-      cookies: cookies?.length,
-      storageDomains: origins?.length,
-    });
-
-    let page: IPuppetPage;
-    try {
-      session.mitmRequestSession.bypassAllWithEmptyResponse = true;
-      page = await session.browserContext.newPage();
-      if (cookies && cookies.length) {
-        await session.browserContext.addCookies(cookies, origins);
-      }
-
-      if (hasStorage) {
-        session.browserContext.domStorage = {};
-
-        // install scripts so we can restore storage
-        await InjectedScripts.installDomStorageRestore(page);
-
-        for (const origin of origins) {
-          const originStorage = storage[origin];
-          if (
-            !originStorage ||
-            (!originStorage.indexedDB.length &&
-              !originStorage.localStorage.length &&
-              !originStorage.sessionStorage.length)
-          ) {
-            continue;
-          }
-
-          try {
-            await page.navigate(origin);
-            await page.mainFrame.evaluate(
-              `window.restoreUserStorage(${JSON.stringify(originStorage)})`,
-              true,
-            );
-
-            session.browserContext.domStorage[origin] = {
-              indexedDB: originStorage.indexedDB.map(x => ({
-                ...x,
-                data: { ...x.data },
-                objectStores: [...x.objectStores],
-              })),
-              sessionStorage: originStorage.sessionStorage.map(x => ({ ...x })),
-              localStorage: originStorage.localStorage.map(x => ({ ...x })),
-            };
-          } catch (error) {
-            throw new Error(
-              `Could not restore profile for origin ("${origin}") => ${error.message}`,
-            );
-          }
-        }
-      }
-    } finally {
-      session.mitmRequestSession.bypassAllWithEmptyResponse = false;
-      if (page) await page.close();
-      log.info('UserProfile.installed', { sessionId, parentLogId });
+    if (cookies && cookies.length) {
+      await session.browserContext.addCookies(cookies, origins);
     }
-
     return this;
   }
 
-  public static async installSessionStorage(session: Session, page: IPuppetPage): Promise<void> {
+  public static async installStorage(session: Session, page: IPuppetPage): Promise<void> {
     const { userProfile } = session;
+    const domStorage = userProfile.storage;
+    if (!domStorage) return;
+    const sessionId = session.id;
+    const origins = Object.keys(domStorage);
+
+    if (!origins.length) return;
+
+    const interceptorHandlers = session.mitmRequestSession.interceptorHandlers;
+
+    const parentLogId = log.info('UserProfile.installStorage', {
+      sessionId,
+      storageDomains: origins?.length,
+    });
 
     try {
-      session.mitmRequestSession.bypassAllWithEmptyResponse = true;
-      // reinstall session storage for the
-      for (const [origin, storage] of Object.entries(userProfile?.storage ?? {})) {
-        if (!storage.sessionStorage.length) continue;
-        const load = page.mainFrame.waitOn('frame-lifecycle', event => event.name === 'load');
-        await page.navigate(origin);
-        await load;
-        await page.mainFrame.evaluate(
-          `${JSON.stringify(
-            storage.sessionStorage,
-          )}.forEach(([key,value]) => sessionStorage.setItem(key,value))`,
-          false,
-        );
+      session.mitmRequestSession.interceptorHandlers = [
+        {
+          urls: origins,
+          handlerFn(url, type, req, res) {
+            let script = '';
+            const originStorage = domStorage[url.origin];
+            const sessionStorage = originStorage?.sessionStorage;
+            if (sessionStorage) {
+              script += `
+for (const [key,value] of ${JSON.stringify(sessionStorage)}) {
+  sessionStorage.setItem(key,value);
+}\n`;
+            }
+            const localStorage = originStorage?.localStorage;
+            if (localStorage) {
+              script += `\n
+for (const [key,value] of ${JSON.stringify(localStorage)}) {
+  localStorage.setItem(key,value);
+}\n`;
+            }
+
+            if (originStorage?.indexedDB) {
+              script += `\n\n 
+             ${InjectedScripts.getIndexedDbStorageRestoreScript(originStorage.indexedDB)}`;
+            }
+
+            res.end(`<html><body>
+<h5>${url.origin}</h5>
+<script>
+${script}
+</script>
+</body></html>`);
+
+            return true;
+          },
+        },
+      ];
+      await page.devtoolsSession.send('Page.setDocumentContent', {
+        frameId: page.mainFrame.id,
+        html: `<html>
+<body>
+<h1>Restoring Dom Storage</h1>
+${origins.map(x => `<iframe src="${x}"></iframe>`).join('\n')}
+</body>
+</html>`,
+      });
+
+      for (const frame of page.frames) {
+        if (frame === page.mainFrame) {
+          // no loader is set, so need to have special handling
+          if (!page.mainFrame.activeLoader.lifecycle.load) {
+            await page.mainFrame.waitOn('frame-lifecycle', x => x.name === 'load');
+          }
+          continue;
+        }
+        await frame.waitForLifecycleEvent('load');
       }
-      await page.navigate('about:blank');
     } finally {
-      session.mitmRequestSession.bypassAllWithEmptyResponse = false;
+      session.mitmRequestSession.interceptorHandlers = interceptorHandlers;
+      log.stats('UserProfile.installedStorage', { sessionId, parentLogId });
+    }
+
+    session.browserContext.domStorage = {};
+
+    for (const [origin, originStorage] of Object.entries(domStorage)) {
+      session.browserContext.domStorage[origin] = {
+        indexedDB: originStorage.indexedDB.map(x => ({
+          ...x,
+          data: { ...x.data },
+          objectStores: [...x.objectStores],
+        })),
+        sessionStorage: originStorage.sessionStorage.map(x => ({ ...x })),
+        localStorage: originStorage.localStorage.map(x => ({ ...x })),
+      };
     }
   }
 }

--- a/core/test/user-profile.test.ts
+++ b/core/test/user-profile.test.ts
@@ -232,7 +232,7 @@ document.querySelector('#session').innerHTML = [session1,session2,session3].join
       },
     };
     for (let i = 0; i < 100; i += 1) {
-      storage[`https://domain${i}.com`] = {
+      storage[`https://${(i === 1 ? 'D' : 'd')}omain${i}.com`] = {
         indexedDB: [],
         localStorage: [
           ['1', '2'],
@@ -324,7 +324,7 @@ localStorage.setItem('Test1', 'value1');
             localStorage: [['test', 'site1.org']],
             sessionStorage: [],
           },
-          'https://site2.org': {
+          'https://SITE2.org': {
             indexedDB: [],
             localStorage: [['test2', 'site2.org']],
             sessionStorage: [],

--- a/mitm/handlers/HeadersHandler.ts
+++ b/mitm/handlers/HeadersHandler.ts
@@ -56,8 +56,16 @@ export default class HeadersHandler {
       // can't register extension content in page
       origin?.startsWith('chrome-extension://')
     ) {
+      session.browserRequestMatcher.resolveBrowserRequest(ctx);
       return;
     }
+
+    // if we're going to block this, don't wait for a resource type
+    if (!ctx.resourceType && session.shouldInterceptRequest(ctx.url.href)) {
+      session.browserRequestMatcher.resolveBrowserRequest(ctx);
+      return;
+    }
+
 
     if (ctx.resourceType === 'Websocket') {
       ctx.browserRequestId = await session.getWebsocketUpgradeRequestId(requestHeaders);

--- a/mitm/handlers/HttpRequestHandler.ts
+++ b/mitm/handlers/HttpRequestHandler.ts
@@ -222,9 +222,9 @@ export default class HttpRequestHandler extends BaseHttpHandler {
     const { serverToProxyResponse, proxyToClientResponse, requestSession, events } = context;
 
     proxyToClientResponse.statusCode = context.status;
+
     // write individually so we properly write header-lists
     for (const [key, value] of Object.entries(context.responseHeaders)) {
-      proxyToClientResponse.setHeader(key, value);
       try {
         proxyToClientResponse.setHeader(key, value);
       } catch (error) {

--- a/mitm/interfaces/IBrowserRequestMatcher.ts
+++ b/mitm/interfaces/IBrowserRequestMatcher.ts
@@ -2,5 +2,6 @@ import IHttpResourceLoadDetails from '@ulixee/hero-interfaces/IHttpResourceLoadD
 
 export default interface IBrowserRequestMatcher {
   cancelPending(): void;
+  resolveBrowserRequest(resource: IHttpResourceLoadDetails): void;
   determineResourceType(resource: IHttpResourceLoadDetails): void;
 }

--- a/mitm/test/basic.test.ts
+++ b/mitm/test/basic.test.ts
@@ -351,6 +351,7 @@ describe('basic MitM tests', () => {
       determineResourceType(resource: IHttpResourceLoadDetails) {
         resource.resourceType = 'Document';
       },
+      resolveBrowserRequest() {},
       cancelPending() {},
     });
     session.plugins.beforeHttpRequest = jest.fn();

--- a/puppet-chrome/lib/Frame.ts
+++ b/puppet-chrome/lib/Frame.ts
@@ -503,6 +503,9 @@ export default class Frame extends TypedEventEmitter<IPuppetFrameEvents> impleme
   private async createIsolatedWorld(): Promise<number> {
     try {
       if (!this.isAttached) return;
+      await new Promise(setImmediate);
+      if (this.isolatedContextId) return this.isolatedContextId;
+
       const isolatedWorld = await this.devtoolsSession.send(
         'Page.createIsolatedWorld',
         {


### PR DESCRIPTION
This PR changes user profiles so they restore in iframe on the first about:blank tab. As a reminder, to restore storage in Chrome, you need to have frames open to each security context. Then we set local/session storage into those tabs. This is a significant speed improvement for bigger profiles, and fixes issues with filechoosers not working when multiple domains are restored, and issues with ChromeAlive losing focus when opening many tabs to restore storage.

----
Session storage is destroyed after a tab is closed, so without updating chrome storage, this is the only way I know to add storage. I've explored whether we could intercept requests to frames/pages and restore dom storage on the fly. However, I can't figure out how to make this the first thing that loads while also silently tracking whether or not a given domain has already been installed. 

Without tracking, you could accidentally try to restore the same session state over something that was modified in interim (for instance - onNewDocumentScript(restoreStorage); go to page; page updates date of entry; page loads frame under domain that triggers script again; script updates date back to old value. 
----

