### PR TITLE
Headers

### DIFF
--- a/mitm/handlers/HeadersHandler.ts
+++ b/mitm/handlers/HeadersHandler.ts
@@ -25,6 +25,10 @@ const SecFetchUser = 'sec-fetch-user';
 const SecFetchMode = 'sec-fetch-mode';
 const PublicKeyPins = 'public-key-pins';
 const Http2Settings = 'http2-settings';
+const nodeVersion = process.version
+  .replace('v', '')
+  .split('.')
+  .map(Number);
 
 export default class HeadersHandler {
   public static async determineResourceType(ctx: IMitmRequestContext): Promise<void> {
@@ -160,16 +164,25 @@ export default class HeadersHandler {
     const url = ctx.url;
     const oldHeaders = ctx.requestHeaders;
     ctx.requestHeaders = Object.create(null);
-    // WORKAROUND: nodejs inserts headers in reverse to front of list, so will mess with the order
-    // to workaround, insert in reverse order
-    // https://github.com/nodejs/node/blob/e46c680bf2b211bbd52cf959ca17ee98c7f657f5/lib/internal/http2/util.js#L521
-    Object.assign(ctx.requestHeaders, {
-      [HTTP2_HEADER_PATH]: url.pathname + url.search,
-      [HTTP2_HEADER_SCHEME]: 'https',
+
+    let headers: IResourceHeaders = {
+      [HTTP2_HEADER_METHOD]: ctx.method,
       [HTTP2_HEADER_AUTHORITY]:
         oldHeaders[HTTP2_HEADER_AUTHORITY] ?? this.getRequestHeader<string>(ctx, 'host'),
-      [HTTP2_HEADER_METHOD]: ctx.method,
-    });
+      [HTTP2_HEADER_SCHEME]: 'https',
+      [HTTP2_HEADER_PATH]: url.pathname + url.search,
+    };
+
+    if (nodeHasPseudoHeaderPatch()) {
+      headers = {
+        [HTTP2_HEADER_PATH]: url.pathname + url.search,
+        [HTTP2_HEADER_SCHEME]: 'https',
+        [HTTP2_HEADER_AUTHORITY]:
+          oldHeaders[HTTP2_HEADER_AUTHORITY] ?? this.getRequestHeader<string>(ctx, 'host'),
+        [HTTP2_HEADER_METHOD]: ctx.method,
+      };
+    }
+    Object.assign(ctx.requestHeaders, headers);
 
     for (const header of Object.keys(oldHeaders)) {
       const lowerKey = toLowerCase(header);
@@ -314,3 +327,15 @@ const singleValueHttp2Headers = new Set([
   http2.constants.HTTP2_HEADER_USER_AGENT,
   'x-content-type-options',
 ]);
+
+function nodeHasPseudoHeaderPatch(): boolean {
+  const [nodeVersionMajor, nodeVersionMinor, nodeVersionPatch] = nodeVersion;
+
+  // Node.js was reversing pseudo-headers as provided. Fixed in 17.5.0, 16.14.1
+  let needsReverseHeaders = nodeVersionMajor <= 17;
+  if (nodeVersionMajor === 17 && nodeVersionMinor >= 5) needsReverseHeaders = false;
+  if (nodeVersionMajor === 16 && nodeVersionMinor === 14 && nodeVersionPatch >= 1)
+    needsReverseHeaders = false;
+  if (nodeVersionMajor === 16 && nodeVersionMinor > 14) needsReverseHeaders = false;
+  return needsReverseHeaders;
+}

--- a/mitm/handlers/HttpRequestHandler.ts
+++ b/mitm/handlers/HttpRequestHandler.ts
@@ -221,6 +221,18 @@ export default class HttpRequestHandler extends BaseHttpHandler {
     const context = this.context;
     const { serverToProxyResponse, proxyToClientResponse, requestSession, events } = context;
 
+    // NOTE: nodejs won't allow an invalid status, but chrome will.
+    // TODO: we should find a way to keep this value
+    if (context.status > 599) {
+      log.info(`MitmHttpRequest.modifyStatusResponseCode`, {
+        sessionId: requestSession.sessionId,
+        request: `${context.method}: ${context.url.href}`,
+        actualStatus: context.status,
+        responseStatus: 599,
+      });
+      context.status = 599;
+    }
+
     proxyToClientResponse.statusCode = context.status;
     // write individually so we properly write header-lists
     for (const [key, value] of Object.entries(context.responseHeaders)) {


### PR DESCRIPTION
1. Accounts for nodejs fix to "reversing" pseudo-header order in 17.5.0 and 16.14.1
2. We have a bug in SecretAgent that status codes > 599 will result in nodejs throwing an error that it can't handle that status code. Chrome, however, will accept status codes outside the range of valid codes. I can't find any way in node.js to use a >599 status code besides writing directly to the socket, which means we're writing all of our own http2 code at that point. In the interim, I think we should just set to 599 and warn. This is a detectable item if someone knows to look for it.