### PR TITLE
feat(client): add pause commands to api

### DIFF
--- a/client/lib/CoreSession.ts
+++ b/client/lib/CoreSession.ts
@@ -204,6 +204,10 @@ export default class CoreSession implements IJsPathEventTarget {
     }
   }
 
+  public async pause(): Promise<void> {
+    await this.commandQueue.run('Session.pauseCommands');
+  }
+
   private async doClose(force: boolean): Promise<{ didKeepAlive: boolean; message: string }> {
     await this.commandQueue.flush();
     for (const tab of this.tabsById.values()) {

--- a/client/lib/Hero.ts
+++ b/client/lib/Hero.ts
@@ -420,6 +420,11 @@ export default class Hero extends AwaitedEventTarget<{
     return await this.getComputedVisibility(element as any).then(x => x.isVisible);
   }
 
+  public async pause(): Promise<void> {
+    const session = await this.#getCoreSessionOrReject();
+    await session.pause();
+  }
+
   public querySelector(selector: string): ISuperNode {
     return this.activeTab.querySelector(selector);
   }

--- a/core/lib/Commands.ts
+++ b/core/lib/Commands.ts
@@ -11,6 +11,8 @@ import { TypedEventEmitter } from '@ulixee/commons/lib/eventUtils';
 export default class Commands extends TypedEventEmitter<{
   start: ICommandMeta;
   finish: ICommandMeta;
+  pause: void;
+  resume: void;
 }> {
   public readonly history: ICommandMeta[] = [];
   public get last(): ICommandMeta | undefined {
@@ -54,11 +56,13 @@ export default class Commands extends TypedEventEmitter<{
     if (!this.commandLockPromise || this.commandLockPromise.isResolved) {
       this.commandLockPromise = new Resolvable();
     }
+    this.emit('pause');
   }
 
   public resume(): void {
     this.commandLockPromise.resolve();
     this.commandLockPromise = null;
+    this.emit('resume');
   }
 
   public create(


### PR DESCRIPTION
This PR exposes pause to the api for use in scripts. You can inject a "pause" into your script and it will pause in ChromeAlive