### PR TITLE
feat(timetravel): timeline extender ms after cmd

### DIFF
--- a/core/lib/CorePlugins.ts
+++ b/core/lib/CorePlugins.ts
@@ -178,10 +178,11 @@ export default class CorePlugins implements ICorePlugins {
   }
 
   public async onBrowserLaunchConfiguration(launchArguments: string[]): Promise<void> {
+    const sessionSummary = this.getSessionSummary();
     await Promise.all(
       this.instances
         .filter(p => p.onBrowserLaunchConfiguration)
-        .map(p => p.onBrowserLaunchConfiguration(launchArguments)),
+        .map(p => p.onBrowserLaunchConfiguration(launchArguments, sessionSummary)),
     );
   }
 
@@ -301,18 +302,20 @@ export default class CorePlugins implements ICorePlugins {
   // MISCELLANEOUS
 
   public async onDevtoolsPanelAttached(devtoolsSession: IDevtoolsSession): Promise<any> {
+    const sessionSummary = this.getSessionSummary();
     await Promise.all(
       this.instances
         .filter(p => p.onDevtoolsPanelAttached)
-        .map(p => p.onDevtoolsPanelAttached(devtoolsSession)),
+        .map(p => p.onDevtoolsPanelAttached(devtoolsSession, sessionSummary)),
     );
   }
 
   public async onDevtoolsPanelDetached(devtoolsSession: IDevtoolsSession): Promise<any> {
+    const sessionSummary = this.getSessionSummary();
     await Promise.all(
       this.instances
         .filter(p => p.onDevtoolsPanelDetached)
-        .map(p => p.onDevtoolsPanelDetached(devtoolsSession)),
+        .map(p => p.onDevtoolsPanelDetached(devtoolsSession, sessionSummary)),
     );
   }
 
@@ -320,10 +323,11 @@ export default class CorePlugins implements ICorePlugins {
     devtoolsSession: IDevtoolsSession,
     event: Protocol.Target.AttachedToTargetEvent,
   ): Promise<any> {
+    const sessionSummary = this.getSessionSummary();
     await Promise.all(
       this.instances
         .filter(p => p.onServiceWorkerAttached)
-        .map(p => p.onServiceWorkerAttached(devtoolsSession, event)),
+        .map(p => p.onServiceWorkerAttached(devtoolsSession, event, sessionSummary)),
     );
   }
 

--- a/core/lib/FrameEnvironment.ts
+++ b/core/lib/FrameEnvironment.ts
@@ -199,7 +199,7 @@ export default class FrameEnvironment
     hideMouse = false,
     hideHighlightedNodes = false,
   ): void {
-    if (!this.session.options.showBrowserInteractions) return;
+    if (!this.session.options.showChromeInteractions) return;
     if (this.isTrackingMouse === followMouseMoves) return;
     this.isTrackingMouse = followMouseMoves;
     this.puppetFrame

--- a/core/lib/GlobalPool.ts
+++ b/core/lib/GlobalPool.ts
@@ -56,7 +56,7 @@ export default class GlobalPool {
     const corePlugins = new CorePlugins({}, log);
 
     this.utilityBrowserContext = this.getPuppet(corePlugins, corePlugins.browserEngine, null, {
-      showBrowser: false,
+      showChrome: false,
       enableMitm: false,
     }).then(puppet => puppet.newContext(corePlugins, log, null, true));
 
@@ -293,9 +293,7 @@ export default class GlobalPool {
 
   private static getPuppetLaunchArgs(): IPuppetLaunchArgs {
     this.defaultLaunchArgs ??= {
-      showBrowser: Boolean(
-        JSON.parse(process.env.HERO_SHOW_BROWSER ?? process.env.SHOW_BROWSER ?? 'false'),
-      ),
+      showChrome: Boolean(JSON.parse(process.env.HERO_SHOW_CHROME ?? 'false')),
       disableDevtools: Boolean(JSON.parse(process.env.HERO_DISABLE_DEVTOOLS ?? 'false')),
       noChromeSandbox: Boolean(JSON.parse(process.env.HERO_NO_CHROME_SANDBOX ?? 'false')),
       disableGpu: Boolean(JSON.parse(process.env.HERO_DISABLE_GPU ?? 'false')),

--- a/core/lib/GlobalPool.ts
+++ b/core/lib/GlobalPool.ts
@@ -16,6 +16,7 @@ import Core from '../index';
 import IPuppetContext from '@ulixee/hero-interfaces/IPuppetContext';
 import ICorePlugins from '@ulixee/hero-interfaces/ICorePlugins';
 import CorePlugins from './CorePlugins';
+import { ISessionSummary } from '@ulixee/hero-interfaces/ICorePlugin';
 
 const { log } = Log(module);
 export const disableMitm = Boolean(JSON.parse(process.env.HERO_DISABLE_MITM ?? 'false'));
@@ -54,7 +55,7 @@ export default class GlobalPool {
 
     const corePlugins = new CorePlugins({}, log);
 
-    this.utilityBrowserContext = this.getPuppet(corePlugins, corePlugins.browserEngine, {
+    this.utilityBrowserContext = this.getPuppet(corePlugins, corePlugins.browserEngine, null, {
       showBrowser: false,
       enableMitm: false,
     }).then(puppet => puppet.newContext(corePlugins, log, null, true));
@@ -136,6 +137,7 @@ export default class GlobalPool {
   public static async getPuppet(
     plugins: ICorePlugins,
     browserEngine: IBrowserEngine,
+    sessionSummary?: ISessionSummary,
     launchArgs?: IPuppetLaunchArgs,
   ): Promise<Puppet> {
     const args = launchArgs ?? this.getPuppetLaunchArgs();
@@ -180,7 +182,11 @@ export default class GlobalPool {
 
       if (session.mode === 'browserless') return session;
 
-      const puppet = await this.getPuppet(session.plugins, session.browserEngine);
+      const puppet = await this.getPuppet(
+        session.plugins,
+        session.browserEngine,
+        session.getSummary(),
+      );
 
       if (disableMitm !== true) {
         await session.registerWithMitm(this.mitmServer, puppet.supportsBrowserContextProxy);

--- a/core/lib/Session.ts
+++ b/core/lib/Session.ts
@@ -221,7 +221,7 @@ export default class Session
       this.resources,
     );
     this.mitmRequestSession.respondWithHttpErrorStacks =
-      this.mode === 'development' && this.options.showBrowserInteractions === true;
+      this.mode === 'development' && this.options.showChromeInteractions === true;
     this.websocketMessages = new WebsocketMessages(this.db);
     this.commands = new Commands(this.db);
     this.commandRecorder = new CommandRecorder(this, this, null, null, [
@@ -250,12 +250,12 @@ export default class Session
   }
 
   public configureHeaded(
-    options: Pick<ISessionCreateOptions, 'showBrowser' | 'showBrowserInteractions'>,
+    options: Pick<ISessionCreateOptions, 'showChrome' | 'showChromeInteractions'>,
   ): void {
-    this.options.showBrowser = options.showBrowser ?? false;
-    this.options.showBrowserInteractions = options.showBrowserInteractions ?? options.showBrowser;
+    this.options.showChrome = options.showChrome ?? false;
+    this.options.showChromeInteractions = options.showChromeInteractions ?? options.showChrome;
 
-    this.browserEngine.isHeaded = this.options.showBrowser;
+    this.browserEngine.isHeaded = this.options.showChrome;
   }
 
   public isAllowedCommand(method: string): boolean {
@@ -399,7 +399,7 @@ export default class Session
     }
 
     context.defaultPageInitializationFn = page =>
-      InjectedScripts.install(page, this.options.showBrowserInteractions);
+      InjectedScripts.install(page, this.options.showChromeInteractions);
 
     const requestSession = this.mitmRequestSession;
     this.events.on(requestSession, 'request', this.onMitmRequest.bind(this));

--- a/core/lib/Session.ts
+++ b/core/lib/Session.ts
@@ -375,11 +375,7 @@ export default class Session
   }
 
   public useIncognitoContext(): boolean {
-    const isChromeAlive =
-      this.options.showBrowser === true &&
-      this.options.sessionKeepAlive === true &&
-      this.mode === 'development';
-    return isChromeAlive === false;
+    return this.options.showChromeAlive !== true;
   }
 
   public async registerWithMitm(

--- a/docs/main/BasicInterfaces/Hero.md
+++ b/docs/main/BasicInterfaces/Hero.md
@@ -80,8 +80,8 @@ const Hero = require('@ulixee/hero');
     - positionY? `number`. Optional override browser Y position on screen in pixels (minimum 0, maximum 10000000).
   - blockedResourceTypes `BlockedResourceType[]`. Controls browser resource loading. Valid options are listed [here](/docs/overview/configuration#blocked-resources).
   - userProfile `IUserProfile`. Previous user's cookies, session, etc.
-  - showBrowser `boolean`. A boolean whether to show the Chrome browser window. Can also be set with an env variable: `HERO_SHOW_BROWSER=true`. Default `false`.
-  - showBrowserInteractions `boolean`. A boolean whether to inject user interactions to mimic headless mouse/keyboard activity. Default `false`.
+  - showChrome `boolean`. A boolean whether to show the Chrome browser window. Can also be set with an env variable: `HERO_SHOW_CHROME=true`. Default `false`.
+  - showChromeInteractions `boolean`. A boolean whether to inject user interactions to mimic headless mouse/keyboard activity. Default `false`.
   - showChromeAlive `boolean`. A boolean whether to show the ChromeAlive! toolbar (if installed in devDependencies, or using Ulixee.app). Default `false`.
   - upstreamProxyUrl `string`. A socks5 or http proxy url (and optional auth) to use for all HTTP requests in this session. The optional "auth" should be included in the UserInfo section of the url, eg: `http://username:password@proxy.com:80`.
   - upstreamProxyIpMask `object`. Optional settings to mask the Public IP Address of a host machine when using a proxy. This is used by the default BrowserEmulator to mask WebRTC IPs.

--- a/docs/main/Plugins/BrowserEmulators.md
+++ b/docs/main/Plugins/BrowserEmulators.md
@@ -31,7 +31,7 @@ This is called every time a new browser engine is started, which may not be ever
 #### **Arguments**:
 
  - launchSettings: `object`
-    - showBrowser: `boolean` - has the user requested to show the browser
+    - showChrome: `boolean` - has the user requested to show the browser
     - disableGpu: `boolean` - has the user requested to disable the gpu
     - disableDevtools: `boolean` - has the user requested to disable automatically showing devtools
 

--- a/examples/news.ycombinator.com.ts
+++ b/examples/news.ycombinator.com.ts
@@ -1,6 +1,6 @@
 import Hero from '@ulixee/hero-fullstack';
 
-// process.env.HERO_SHOW_BROWSER = 'true';
+// process.env.HERO_SHOW_CHROME = 'true';
 
 async function run() {
   const hero = new Hero({ userAgent: '~ chrome = 89' });

--- a/examples/sessionResume.ts
+++ b/examples/sessionResume.ts
@@ -8,8 +8,8 @@ const resumeSessionId = Fs.existsSync(sessionIdPath)
 
 (async () => {
   const hero = new Hero({
-    showBrowserInteractions: true, // disable to remove mouse movements and node highlights (can be detected by page!)
-    showBrowser: true,
+    showChromeInteractions: true, // disable to remove mouse movements and node highlights (can be detected by page!)
+    showChrome: true,
     sessionKeepAlive: true,
     sessionResume: {
       startLocation: 'currentLocation', // 'currentLocation | pageStart', // default: currentLocation

--- a/examples/show-browser.js
+++ b/examples/show-browser.js
@@ -1,11 +1,11 @@
 const Hero = require('@ulixee/hero-fullstack');
 
-//process.env.HERO_SHOW_BROWSER = 'true';
+//process.env.HERO_SHOW_CHROME = 'true';
 
 (async () => {
   const url = `https://dataliberationfoundation.org/`;
   console.log('Opened Browser');
-  const hero = new Hero({ showBrowserInteractions: true, showBrowser: true });
+  const hero = new Hero({ showChromeInteractions: true, showChrome: true });
 
   await hero.goto(url, 5e3);
   await hero.waitForPaintingStable();

--- a/interfaces/ICorePlugin.ts
+++ b/interfaces/ICorePlugin.ts
@@ -36,11 +36,18 @@ export interface ICorePluginClass {
 
 export interface ICorePluginMethods {
   onClientCommand?(meta: IOnClientCommandMeta, ...args: any[]): Promise<any>;
-  onDevtoolsPanelAttached?(devtoolsSession: IDevtoolsSession): Promise<any>;
-  onDevtoolsPanelDetached?(devtoolsSession: IDevtoolsSession): Promise<any>;
+  onDevtoolsPanelAttached?(
+    devtoolsSession: IDevtoolsSession,
+    sessionSummary?: ISessionSummary,
+  ): Promise<any>;
+  onDevtoolsPanelDetached?(
+    devtoolsSession: IDevtoolsSession,
+    sessionSummary?: ISessionSummary,
+  ): Promise<any>;
   onServiceWorkerAttached?(
     devtoolsSession: IDevtoolsSession,
     event: Protocol.Target.AttachedToTargetEvent,
+    sessionSummary?: ISessionSummary,
   ): Promise<any>;
 }
 
@@ -121,7 +128,7 @@ export interface IBrowserEmulator extends ICorePlugin {
 export interface IBrowserEmulatorMethods {
   configure?(options: IBrowserEmulatorConfig, sessionSummary?: ISessionSummary): void;
 
-  onBrowserLaunchConfiguration?(launchArguments: string[]): Promise<void> | void;
+  onBrowserLaunchConfiguration?(launchArguments: string[], sessionSummary?: ISessionSummary): Promise<void> | void;
 
   onDnsConfiguration?(settings: IDnsSettings, sessionSummary?: ISessionSummary): void;
   onTcpConfiguration?(settings: ITcpSettings, sessionSummary?: ISessionSummary): void;

--- a/interfaces/ICorePlugin.ts
+++ b/interfaces/ICorePlugin.ts
@@ -98,7 +98,7 @@ export interface IBrowserEmulatorClass {
   onBrowserWillLaunch?(
     browserEngine: IBrowserEngine,
     launchSettings: {
-      showBrowser?: boolean;
+      showChrome?: boolean;
       disableGpu?: boolean;
       disableDevtools?: boolean;
     },

--- a/interfaces/ILaunchOptions.ts
+++ b/interfaces/ILaunchOptions.ts
@@ -1,5 +1,5 @@
 export default interface ILaunchOptions {
-  showBrowser?: boolean;
+  showChrome?: boolean;
   executablePath: string;
   proxyPort: number;
   dumpio?: boolean;

--- a/interfaces/IPuppetLaunchArgs.ts
+++ b/interfaces/IPuppetLaunchArgs.ts
@@ -1,6 +1,6 @@
 export default interface IPuppetLaunchArgs {
   proxyPort?: number;
-  showBrowser?: boolean;
+  showChrome?: boolean;
   disableDevtools?: boolean;
   disableGpu?: boolean;
   noChromeSandbox?: boolean;

--- a/interfaces/ISessionCreateOptions.ts
+++ b/interfaces/ISessionCreateOptions.ts
@@ -27,7 +27,7 @@ export default interface ISessionCreateOptions extends ISessionOptions {
   dependencyMap?: { [clientPluginId: string]: string[] };
   corePluginPaths?: string[];
   dnsOverTlsProvider?: { host: string; servername: string; port?: number };
-  showBrowser?: boolean;
+  showChrome?: boolean;
   showChromeAlive?: boolean;
-  showBrowserInteractions?: boolean;
+  showChromeInteractions?: boolean;
 }

--- a/plugin-utils/lib/BrowserEngine.ts
+++ b/plugin-utils/lib/BrowserEngine.ts
@@ -62,7 +62,7 @@ ${remedyMessage}`);
   }
 
   public beforeLaunch(launchSettings: {
-    showBrowser?: boolean;
+    showChrome?: boolean;
     disableGpu?: boolean;
     disableDevtools?: boolean;
   }): void {

--- a/plugins/default-browser-emulator/index.ts
+++ b/plugins/default-browser-emulator/index.ts
@@ -219,7 +219,7 @@ export default class DefaultBrowserEmulator extends BrowserEmulator {
   public static onBrowserWillLaunch(
     browserEngine: BrowserEngine,
     options: {
-      showBrowser?: boolean;
+      showChrome?: boolean;
       disableGpu?: boolean;
       disableDevtools?: boolean;
     },

--- a/plugins/default-browser-emulator/lib/helpers/configureBrowserLaunchArgs.ts
+++ b/plugins/default-browser-emulator/lib/helpers/configureBrowserLaunchArgs.ts
@@ -8,7 +8,7 @@ let sessionDirCounter = 0;
 export function configureBrowserLaunchArgs(
   engine: BrowserEngine,
   options: {
-    showBrowser?: boolean;
+    showChrome?: boolean;
     disableGpu?: boolean;
     disableDevtools?: boolean;
   },
@@ -57,7 +57,7 @@ export function configureBrowserLaunchArgs(
     '--no-startup-window',
   );
 
-  if (options.showBrowser) {
+  if (options.showChrome) {
     const dataDir = Path.join(
       os.tmpdir(),
       engine.fullVersion.replace('.', '-'),

--- a/puppet-chrome/index.ts
+++ b/puppet-chrome/index.ts
@@ -35,7 +35,7 @@ const PuppetLauncher: IPuppetLauncher = {
       }
     }
 
-    browserEngine.isHeaded = options.showBrowser === true;
+    browserEngine.isHeaded = options.showChrome === true;
     if (!browserEngine.isHeaded) {
       chromeArguments.push('--headless');
     }

--- a/puppet/index.ts
+++ b/puppet/index.ts
@@ -37,7 +37,7 @@ export default class Puppet extends TypedEventEmitter<{ close: void }> {
     this.browserEngine = browserEngine;
     this.id = puppBrowserCounter;
     if (browserEngine.name === 'chrome') {
-      if (browserEngine.isHeaded) args.showBrowser = true;
+      if (browserEngine.isHeaded) args.showChrome = true;
       PuppetChrome.getLaunchArgs(args, browserEngine);
       this.launcher = PuppetChrome;
     } else {

--- a/timetravel/lib/MirrorContext.ts
+++ b/timetravel/lib/MirrorContext.ts
@@ -12,8 +12,8 @@ export default class MirrorContext {
   ): Promise<IPuppetContext> {
     const options = Session.restoreOptionsFromSessionRecord({}, sessionId);
     options.sessionResume = null;
-    options.showBrowserInteractions = headed;
-    options.showBrowser = headed;
+    options.showChromeInteractions = headed;
+    options.showChrome = headed;
 
     const plugins = new CorePlugins(
       {
@@ -30,7 +30,7 @@ export default class MirrorContext {
       },
       log,
     );
-    plugins.browserEngine.isHeaded = options.showBrowser;
+    plugins.browserEngine.isHeaded = options.showChrome;
     plugins.configure(options);
 
     const puppet = await GlobalPool.getPuppet(plugins, plugins.browserEngine);

--- a/timetravel/lib/MirrorPage.ts
+++ b/timetravel/lib/MirrorPage.ts
@@ -53,7 +53,7 @@ export default class MirrorPage extends TypedEventEmitter<{
   constructor(
     public network: MirrorNetwork,
     domRecording: IDomRecording,
-    private showBrowserInteractions = false,
+    private showChromeInteractions = false,
     private debugLogging = false,
   ) {
     super();
@@ -96,7 +96,7 @@ export default class MirrorPage extends TypedEventEmitter<{
 
       } else {
         promises.push(
-          this.showBrowserInteractions ? InjectedScripts.installInteractionScript(page, false) : null,
+          this.showChromeInteractions ? InjectedScripts.installInteractionScript(page, false) : null,
           page.addNewDocumentScript(injectedScript, false).then(() => page.reload()),
         );
       }
@@ -223,7 +223,7 @@ export default class MirrorPage extends TypedEventEmitter<{
           });
         }
 
-        const showOverlay = (overlayLabel || isLoadingDocument) && this.showBrowserInteractions;
+        const showOverlay = (overlayLabel || isLoadingDocument) && this.showChromeInteractions;
 
         if (showOverlay) await this.evaluate('window.overlay();');
 
@@ -246,7 +246,7 @@ export default class MirrorPage extends TypedEventEmitter<{
     mouse: IMouseEventRecord,
     scroll: IScrollRecord,
   ): Promise<void> {
-    if (!this.showBrowserInteractions) return;
+    if (!this.showChromeInteractions) return;
     const args = [highlightNodeIds, mouse, scroll].map(x => {
       if (!x) return 'undefined';
       return JSON.stringify(this.applyFrameNodePath(x));
@@ -255,7 +255,7 @@ export default class MirrorPage extends TypedEventEmitter<{
   }
 
   public async showStatusText(text: string): Promise<void> {
-    if (!this.showBrowserInteractions) return;
+    if (!this.showChromeInteractions) return;
     await this.evaluate(`window.showReplayStatus("${text}");`);
   }
 

--- a/timetravel/test/mirrorPage.test.ts
+++ b/timetravel/test/mirrorPage.test.ts
@@ -57,7 +57,7 @@ describe('MirrorPage tests', () => {
     const meta = await connectionToClient.createSession();
     const tab = Session.getTab(meta);
     Helpers.needsClosing.push(tab.session);
-    tab.session.options.showBrowserInteractions = true;
+    tab.session.options.showChromeInteractions = true;
     await InjectedScripts.installInteractionScript(tab.puppetPage);
     await tab.goto(`${koaServer.baseUrl}/domrecording`);
     await tab.waitForLoad('DomContentLoaded');


### PR DESCRIPTION
Modified the TimelineRecorder (which used to activate and cancel creating timestamps) to a TimelineWatch, which will emit events when the timeline changes, and will optionally extend the timeline (ie, close time) by X ms after the last command, or X ms after the last status. This allows us to say, extend the session 2 seconds after the last command finished, or 2 seconds after ContentLoaded occurs, which is important for making the StateGenerator usable.

Also changed session create options `showBrowser` to `showChrome` and `showBrowserInteractions` to `showChromeInteractions`