### PR TITLE
fix(core): fix profile restore

### DIFF
--- a/client/lib/Hero.ts
+++ b/client/lib/Hero.ts
@@ -11,7 +11,10 @@ import Response from 'awaited-dom/impl/official-klasses/Response';
 import { ISuperElement, ISuperNode, ISuperNodeList } from 'awaited-dom/base/interfaces/super';
 import IWaitForResourceOptions from '@ulixee/hero-interfaces/IWaitForResourceOptions';
 import IWaitForElementOptions from '@ulixee/hero-interfaces/IWaitForElementOptions';
-import { ILocationTrigger } from '@unblocked-web/specifications/agent/browser/Location';
+import {
+  ILoadStatus,
+  ILocationTrigger,
+} from '@unblocked-web/specifications/agent/browser/Location';
 import Request from 'awaited-dom/impl/official-klasses/Request';
 import IWaitForOptions from '@ulixee/hero-interfaces/IWaitForOptions';
 import {
@@ -471,6 +474,10 @@ export default class Hero extends AwaitedEventTarget<{
 
   public waitForLocation(trigger: ILocationTrigger, options?: IWaitForOptions): Promise<Resource> {
     return this.activeTab.waitForLocation(trigger, options);
+  }
+
+  public waitForLoad(status: ILoadStatus, options?: IWaitForOptions): Promise<void> {
+    return this.activeTab.waitForLoad(status, options);
   }
 
   public waitForMillis(millis: number): Promise<void> {

--- a/core/injected-scripts/domStorage.ts
+++ b/core/injected-scripts/domStorage.ts
@@ -68,7 +68,10 @@ async function readStoreData(store: IDBObjectStore) {
       const cursor = (event.target as IDBRequest<IDBCursorWithValue>).result;
       if (cursor) {
         const key = store.keyPath === null ? cursor.key : undefined;
-        const value = cursor.value;
+        let value = cursor.value;
+        if (typeof value === 'object') {
+          value = { ...value };
+        }
         data.push(TypeSerializer.stringify({ key, value }));
         cursor.continue();
       } else {

--- a/core/test/user-profile.test.ts
+++ b/core/test/user-profile.test.ts
@@ -526,7 +526,10 @@ describe('UserProfile IndexedDb tests', () => {
         tab.mainFrameEnvironment,
       );
 
-      await expect(tab.session.exportUserProfile()).resolves.toBeTruthy();
+      const profile = await tab.session.exportUserProfile();
+      expect(profile).toBeTruthy();
+      expect(profile.storage[koaServer.baseUrl]).toBeTruthy()
+      expect(profile.storage[koaServer.baseUrl].indexedDB).toHaveLength(0)
     }
   });
 

--- a/docs/main/AdvancedClient/ConnectionToCore.md
+++ b/docs/main/AdvancedClient/ConnectionToCore.md
@@ -13,7 +13,7 @@ const { Hero: PlaygroundHero } = require('@ulixee/hero-playground');
   const local = new PlaygroundHero();
   // dials a Remote Core
   const remote = new BaseHero({
-    ConnectionToHeroCore: new ConnectionToHeroCore.remote('192.168.1.1:3444'),
+    ConnectionToHeroCore: ConnectionToHeroCore.remote('192.168.1.1:3444'),
   });
 })().catch(console.log);
 ```


### PR DESCRIPTION
Needed a few fixes for profiles:
1. null indexed db entries needed to be filtered
2. wasn't properly exporting some types of object entries (and then couldn't be restored)

closes #133 