### PR TITLE
Update wrong documentation urls

### DIFF
--- a/docs/main/AdvancedClient/FrameEnvironment.md
+++ b/docs/main/AdvancedClient/FrameEnvironment.md
@@ -24,7 +24,7 @@ Returns a [CookieStorage](/docs/hero/advanced-client/cookie-storage) instance to
 
 Returns a reference to the document of the frameEnvironment.
 
-#### **Type**: [`SuperDocument`](/docs/awaited-dom/super-document)
+#### **Type**: [`SuperDocument`](/docs/hero/awaited-dom/super-document)
 
 ### frameEnvironment.frameId {#frameid}
 
@@ -66,9 +66,9 @@ An execution point that refers to a command run on this Hero instance (`waitForE
 
 ### frameEnvironment.localStorage <div class="specs"><i>W3C</i></div> {#local-storage}
 
-Returns a reference to the [Storage](/docs/awaited-dom/storage) object managing localStorage for the frameEnvironment.
+Returns a reference to the [Storage](/docs/hero/awaited-dom/storage) object managing localStorage for the frameEnvironment.
 
-#### **Type**: [`Storage`](/docs/awaited-dom/storage)
+#### **Type**: [`Storage`](/docs/hero/awaited-dom/storage)
 
 ### frameEnvironment.parentFrameId {#parent-frameid}
 
@@ -84,9 +84,9 @@ Returns the name given to the frame DOM element. NOTE: this name is not populate
 
 ### frameEnvironment.sessionStorage <div class="specs"><i>W3C</i></div> {#session-storage}
 
-Returns a reference to the [Storage](/docs/awaited-dom/storage) object managing sessionStorage for the frameEnvironment.
+Returns a reference to the [Storage](/docs/hero/awaited-dom/storage) object managing sessionStorage for the frameEnvironment.
 
-#### **Type**: [`Storage`](/docs/awaited-dom/storage)
+#### **Type**: [`Storage`](/docs/hero/awaited-dom/storage)
 
 ### frameEnvironment.url {#url}
 
@@ -96,7 +96,7 @@ The url of the active frameEnvironment.
 
 ### frameEnvironment.Request <div class="specs"><i>W3C</i></div> {#request-type}
 
-Returns a constructor for a [Request](/docs/awaited-dom/request) object that can be sent to [frameEnvironment.fetch(request)](#fetch).
+Returns a constructor for a [Request](/docs/hero/awaited-dom/request) object that can be sent to [frameEnvironment.fetch(request)](#fetch).
 
 ```js
 const { Request, fetch } = hero;
@@ -109,7 +109,7 @@ const request = new Request(url, {
 const response = await fetch(request);
 ```
 
-#### **Type**: [`Request`](/docs/awaited-dom/request)
+#### **Type**: [`Request`](/docs/hero/awaited-dom/request)
 
 ## Methods
 
@@ -124,7 +124,7 @@ Perform a native "fetch" request in the current frame environment.
   - Inbound Body currently supports: `string`, `ArrayBuffer`, `null`.
   - Not supported: `Blob`, `FormData`, `ReadableStream`, `URLSearchParams`
 
-#### **Returns**: [`Promise<Response>`](/docs/awaited-dom/response)
+#### **Returns**: [`Promise<Response>`](/docs/hero/awaited-dom/response)
 
 ```js
 const origin = 'https://dataliberationfoundation.org/';
@@ -160,7 +160,7 @@ Get the [FrameEnvironment](/docs/hero/advanced-client/frame-environment) object 
 
 #### **Arguments**:
 
-- element [`SuperElement`](/docs/awaited-dom/super-element) A frame or iframe element loaded in this frame environment (ie, a direct child element of this frame document).
+- element [`SuperElement`](/docs/hero/awaited-dom/super-element) A frame or iframe element loaded in this frame environment (ie, a direct child element of this frame document).
 
 #### **Returns**: [`Promise<Frame>`](/docs/hero/advanced-client/frame-environment)
 
@@ -180,10 +180,10 @@ Perform a native `Window.getComputedStyle` request in the current frame context 
 
 #### **Arguments**:
 
-- element [`SuperElement`](/docs/awaited-dom/super-element) An element loaded in this frame environment.
+- element [`SuperElement`](/docs/hero/awaited-dom/super-element) An element loaded in this frame environment.
 - pseudoElement `string?` Optional string specifying the pseudo-element to match (eg, ::before, ::after, etc). More information can be found on [w3c](https://www.w3.org/TR/css-pseudo-4/).
 
-#### **Returns**: [`Promise<CssStyleDeclaration>`](/docs/awaited-dom/cssstyledeclaration)
+#### **Returns**: [`Promise<CssStyleDeclaration>`](/docs/hero/awaited-dom/cssstyledeclaration)
 
 ```js
 await hero.goto('https://dataliberationfoundation.org');
@@ -207,7 +207,7 @@ Alias for [tab.mainFrameEnvironment.getComputedVisibility](/docs/hero/advanced-c
 
 #### **Arguments**:
 
-- node [`SuperNode`](/docs/awaited-dom/super-node). The node to compute visibility.
+- node [`SuperNode`](/docs/hero/awaited-dom/super-node). The node to compute visibility.
 
 #### **Returns**: `Promise<INodeVisibility>` Boolean values indicating if the node (or closest element) is visible to an end user.
 
@@ -251,7 +251,7 @@ Determines if an element is visible to an end user. This method checks whether a
 
 #### **Arguments**:
 
-- element [`SuperElement`](/docs/awaited-dom/super-element). The element to determine visibility.
+- element [`SuperElement`](/docs/hero/awaited-dom/super-element). The element to determine visibility.
 
 #### **Returns**: `Promise<boolean>` Whether the element is visible to an end user.
 
@@ -259,13 +259,13 @@ Determines if an element is visible to an end user. This method checks whether a
 
 This is a shortcut for document.querySelector.
 
-#### **Returns**: [`SuperNode`](/docs/awaited-dom/super-node). A Node that satisfies the given patterns. Evaluates to null if awaited and not present.
+#### **Returns**: [`SuperNode`](/docs/hero/awaited-dom/super-node). A Node that satisfies the given patterns. Evaluates to null if awaited and not present.
 
 ### frameEnvironment.querySelectorAll *(stringOrOptions)* {#query-selector-all}
 
 This is a shortcut for document.querySelectorAll.
 
-#### **Returns**: [`SuperNodeList`](/docs/awaited-dom/super-node-list). A NodeList that satisfies the given selector. Returns an empty list if a resultset is not found.
+#### **Returns**: [`SuperNodeList`](/docs/hero/awaited-dom/super-node-list). A NodeList that satisfies the given selector. Returns an empty list if a resultset is not found.
 
 ### frameEnvironment.xpathSelector *(selector, orderedResults)* {#xpath-selector}
 
@@ -276,7 +276,7 @@ This is a shortcut for document.evaluate(`selector`, document, `FIRST_ORDERED_NO
 - selector `string`. An XPath selector that can return a single node result.
 - orderedResults `boolean`. Optional boolean to indicate if results should return first ordered result. Default is false.
 
-#### **Returns**: [`SuperNode`](/docs/awaited-dom/super-node). A Node that satisfies the given patterns. Evaluates to null if awaited and not present.
+#### **Returns**: [`SuperNode`](/docs/hero/awaited-dom/super-node). A Node that satisfies the given patterns. Evaluates to null if awaited and not present.
 
 ### frameEnvironment.xpathSelectorAll *(selector, orderedResults)* {#xpath-selector-all}
 
@@ -289,7 +289,7 @@ NOTE: this API will iterate through the results to return an array of all matchi
 - selector `string`. An XPath selector that can return node results.
 - orderedResults `boolean`. Optional boolean to indicate if results should return first ordered result. Default is false.
 
-#### **Returns**: Promise<Array<[`SuperNode`](/docs/awaited-dom/super-node)>>. A promise resolving to an array of nodes that satisfies the given pattern.
+#### **Returns**: Promise<Array<[`SuperNode`](/docs/hero/awaited-dom/super-node)>>. A promise resolving to an array of nodes that satisfies the given pattern.
 
 ### frameEnvironment.waitForPaintingStable *(options)* {#wait-for-painting-stable}
 
@@ -311,7 +311,7 @@ Wait until a specific element is present in the dom.
 
 #### **Arguments**:
 
-- element [`SuperElement`](/docs/awaited-dom/super-element)
+- element [`SuperElement`](/docs/hero/awaited-dom/super-element)
 - options `object` Accepts any of the following:
   - timeoutMs `number`. Timeout in milliseconds. Default `30,000`.
   - waitForVisible `boolean`. Wait until this element is visible to a user (see [getComputedVisibility](#get-computed-visibility).

--- a/docs/main/AdvancedClient/Tab.md
+++ b/docs/main/AdvancedClient/Tab.md
@@ -24,7 +24,7 @@ Returns a reference to the document of the [mainFrameEnvironment](#main-frame-en
 
 Alias for [tab.mainFrameEnvironment.document](/docs/hero/advanced-client/frame-environment#document).
 
-#### **Type**: [`SuperDocument`](/docs/awaited-dom/super-document)
+#### **Type**: [`SuperDocument`](/docs/hero/awaited-dom/super-document)
 
 ### tab.frameEnvironments {#frame-environments}
 
@@ -72,11 +72,11 @@ An execution point that refers to a command run on this Hero instance (`waitForE
 
 ### tab.localStorage <div class="specs"><i>W3C</i></div> {#local-storage}
 
-Returns a reference to the [Storage](/docs/awaited-dom/storage) object managing localStorage for the [mainFrameEnvironment](#main-frame-environment) of this tab.
+Returns a reference to the [Storage](/docs/hero/awaited-dom/storage) object managing localStorage for the [mainFrameEnvironment](#main-frame-environment) of this tab.
 
 Alias for [tab.mainFrameEnvironment.localStorage](/docs/hero/advanced-client/frame-environment#local-storage).
 
-#### **Type**: [`Storage`](/docs/awaited-dom/storage)
+#### **Type**: [`Storage`](/docs/hero/awaited-dom/storage)
 
 ### tab.mainFrameEnvironment {#main-frame-environment}
 
@@ -86,11 +86,11 @@ Returns the [`FrameEnvironment`](/docs/hero/advanced-client/frame-environment) r
 
 ### tab.sessionStorage <div class="specs"><i>W3C</i></div> {#session-storage}
 
-Returns a reference to the [Storage](/docs/awaited-dom/storage) object managing sessionStorage for the [mainFrameEnvironment](#main-frame-environment) of this tab.
+Returns a reference to the [Storage](/docs/hero/awaited-dom/storage) object managing sessionStorage for the [mainFrameEnvironment](#main-frame-environment) of this tab.
 
 Alias for [tab.mainFrameEnvironment.sessionStorage](/docs/hero/advanced-client/frame-environment#session-storage).
 
-#### **Type**: [`Storage`](/docs/awaited-dom/storage)
+#### **Type**: [`Storage`](/docs/hero/awaited-dom/storage)
 
 ### tab.tabId {#tabid}
 
@@ -106,11 +106,11 @@ The url of the active tab.
 
 ### tab.Request <div class="specs"><i>W3C</i></div> {#request-type}
 
-Returns a constructor for a [Request](/docs/awaited-dom/request) object in the [mainFrameEnvironment](#main-frame-environment).
+Returns a constructor for a [Request](/docs/hero/awaited-dom/request) object in the [mainFrameEnvironment](#main-frame-environment).
 
 Alias for [tab.mainFrameEnvironment.Request](/docs/hero/advanced-client/frame-environment#request-type)
 
-#### **Type**: [`Request`](/docs/awaited-dom/request)
+#### **Type**: [`Request`](/docs/hero/awaited-dom/request)
 
 ## Methods
 
@@ -136,7 +136,7 @@ from a different [FrameEnvironment](/docs/hero/advanced-client/frame-environment
 
 Alias for [tab.mainFrameEnvironment.fetch](/docs/hero/advanced-client/frame-environment#fetch)
 
-#### **Returns**: [`Promise<Response>`](/docs/awaited-dom/response)
+#### **Returns**: [`Promise<Response>`](/docs/hero/awaited-dom/response)
 
 ```js
 const origin = 'https://dataliberationfoundation.org/';
@@ -249,10 +249,10 @@ Alias for [tab.mainFrameEnvironment.getComputedStyle](/docs/hero/advanced-client
 
 #### **Arguments**:
 
-- element [`SuperElement`](/docs/awaited-dom/super-element) An element loaded in this tab environment.
+- element [`SuperElement`](/docs/hero/awaited-dom/super-element) An element loaded in this tab environment.
 - pseudoElement `string?` Optional string specifying the pseudo-element to match (eg, ::before, ::after, etc). More information can be found on [w3c](https://www.w3.org/TR/css-pseudo-4/).
 
-#### **Returns**: [`Promise<CssStyleDeclaration>`](/docs/awaited-dom/cssstyledeclaration)
+#### **Returns**: [`Promise<CssStyleDeclaration>`](/docs/hero/awaited-dom/cssstyledeclaration)
 
 ```js
 await hero.goto('https://dataliberationfoundation.org');
@@ -327,7 +327,7 @@ Alias for [tab.mainFrameEnvironment.getComputedVisibility](/docs/hero/advanced-c
 
 #### **Arguments**:
 
-- node [`SuperNode`](/docs/awaited-dom/super-node). The node to determine visibility.
+- node [`SuperNode`](/docs/hero/awaited-dom/super-node). The node to determine visibility.
 
 #### **Returns**: `Promise<INodeVisibility>` Boolean values indicating if the node (or closest element) is visible to an end user.
 
@@ -349,13 +349,13 @@ Alias for [tab.mainFrameEnvironment.getComputedVisibility](/docs/hero/advanced-c
 
 This is a shortcut for mainFrame.document.querySelector.
 
-#### **Returns**: [`SuperNode`](/docs/awaited-dom/super-node). A Node that satisfies the given patterns. Evaluates to null if awaited and not present.
+#### **Returns**: [`SuperNode`](/docs/hero/awaited-dom/super-node). A Node that satisfies the given patterns. Evaluates to null if awaited and not present.
 
 ### tab.querySelectorAll *(stringOrOptions)* {#query-selector-all}
 
 This is a shortcut for mainFrame.document.querySelectorAll.
 
-#### **Returns**: [`SuperNodeList`](/docs/awaited-dom/super-node-list). A NodeList that satisfies the given patterns. Returns an empty list if a resultset is not found that satisfies the constraints.
+#### **Returns**: [`SuperNodeList`](/docs/hero/awaited-dom/super-node-list). A NodeList that satisfies the given patterns. Returns an empty list if a resultset is not found that satisfies the constraints.
 
 ### tab.registerFlowHandler *(name, state, handlerFn)* {#register-flow-handler}
 
@@ -459,7 +459,7 @@ Alias for [tab.mainFrameEnvironment.waitForElement](/docs/hero/advanced-client/f
 
 #### **Arguments**:
 
-- element [`SuperElement`](/docs/awaited-dom/super-element)
+- element [`SuperElement`](/docs/hero/awaited-dom/super-element)
 - options `object` Accepts any of the following:
   - timeoutMs `number`. Timeout in milliseconds. Default `30,000`.
   - waitForVisible `boolean`. Wait until this element is visible to a user (see [getComputedVisibility](#get-computed-visibility).
@@ -720,7 +720,7 @@ This is a shortcut for mainFrame.document.evaluate(`selector`, document, `FIRST_
 - selector `string`. An XPath selector that can return a single node result.
 - orderedResults `boolean`. Optional boolean to indicate if results should return first ordered result. Default is false.
 
-#### **Returns**: [`SuperNode`](/docs/awaited-dom/super-node). A Node that satisfies the given patterns. Evaluates to null if awaited and not present.
+#### **Returns**: [`SuperNode`](/docs/hero/awaited-dom/super-node). A Node that satisfies the given patterns. Evaluates to null if awaited and not present.
 
 ### tab.xpathSelectorAll *(selector, orderedResults)* {#xpath-selector-all}
 
@@ -733,7 +733,7 @@ NOTE: this API will iterate through the results to return an array of all matchi
 - selector `string`. An XPath selector that can return node results.
 - orderedResults `boolean`. Optional boolean to indicate if results should return first ordered result. Default is false.
 
-#### **Returns**: Promise<Array<[`SuperNode`](/docs/awaited-dom/super-node)>>. A promise resolving to an array of nodes that satisfies the given pattern.
+#### **Returns**: Promise<Array<[`SuperNode`](/docs/hero/awaited-dom/super-node)>>. A promise resolving to an array of nodes that satisfies the given pattern.
 
 ## Events
 

--- a/docs/main/BasicClient/AwaitedDOM-Extensions.md
+++ b/docs/main/BasicClient/AwaitedDOM-Extensions.md
@@ -2,7 +2,7 @@
 
 > AwaitedDOM Extensions add extra functionality to the DOM specification in order to make using Hero easier. All extensions are prefixed with a "$" character.
 
-These extensions are automatically added to all AwaitedDOM elements ([`Nodes`](/docs/awaited-dom/super-node), [`Elements`](/docs/awaited-dom/super-element), [`HTMLElements`](/docs/awaited-dom/super-html-element)) and collections ([`NodeList`](/docs/awaited-dom/super-node-list) and [`HTMLCollections`](/docs/awaited-dom/super-html-collection)).
+These extensions are automatically added to all AwaitedDOM elements ([`Nodes`](/docs/hero/awaited-dom/super-node), [`Elements`](/docs/hero/awaited-dom/super-element), [`HTMLElements`](/docs/hero/awaited-dom/super-html-element)) and collections ([`NodeList`](/docs/hero/awaited-dom/super-node-list) and [`HTMLCollections`](/docs/hero/awaited-dom/super-html-collection)).
 
 ## Properties
 
@@ -72,7 +72,7 @@ Attached to Nodes and Elements ([see list](#super-nodes)).
 
 ## Element Methods
 
-The following methods are added to ([`Nodes`](/docs/awaited-dom/super-node), [`Elements`](/docs/awaited-dom/super-element), and [`HTMLElements`](/docs/awaited-dom/super-html-element)).
+The following methods are added to ([`Nodes`](/docs/hero/awaited-dom/super-node), [`Elements`](/docs/hero/awaited-dom/super-element), and [`HTMLElements`](/docs/hero/awaited-dom/super-html-element)).
 
 
 ### element.$addToDetachedElements *(name)* {#addToDetachedElements}
@@ -240,7 +240,7 @@ Attached to Nodes and Elements ([see list](#super-nodes)).
 
 ## Collection Methods
 
-The following methods are added to ([`NodeList`](/docs/awaited-dom/super-node-list) and [`HTMLCollections`](/docs/awaited-dom/super-html-collection)).
+The following methods are added to ([`NodeList`](/docs/hero/awaited-dom/super-node-list) and [`HTMLCollections`](/docs/hero/awaited-dom/super-html-collection)).
 
 ### collection.$map *(iteratorFn)* {#map}
 

--- a/docs/main/BasicClient/Hero.md
+++ b/docs/main/BasicClient/Hero.md
@@ -117,7 +117,7 @@ DetachedResources object providing access to all resources that have been detach
 
 Returns a reference to the main Document for the active tab.
 
-#### **Type**: [`SuperDocument`](/docs/awaited-dom/super-document)
+#### **Type**: [`SuperDocument`](/docs/hero/awaited-dom/super-document)
 
 Alias for [activeTab.document](/docs/hero/basic-client/tab#document)
 
@@ -173,7 +173,7 @@ Returns a reference to the document of the [mainFrameEnvironment](#main-frame-en
 
 Alias for [tab.mainFrameEnvironment.document](/docs/hero/advanced-client/frame-environment#document).
 
-#### **Type**: [`SuperDocument`](/docs/awaited-dom/super-document)
+#### **Type**: [`SuperDocument`](/docs/hero/awaited-dom/super-document)
 
 ### hero.meta {#meta}
 
@@ -232,7 +232,7 @@ Alias for [Tab.url](/docs/hero/basic-client/tab#url)
 
 Returns a constructor for a Request object bound to the `activeTab`. Proxies to [tab.Request](/docs/hero/basic-client/tab#request-type). These objects can be used to run browser-native [tab.fetch](/docs/hero/basic-client/tab#fetch) requests from the context of the Tab document.
 
-#### **Type**: [`Request`](/docs/awaited-dom/request)
+#### **Type**: [`Request`](/docs/hero/awaited-dom/request)
 
 Alias for [Tab.Request](/docs/hero/basic-client/tab#request-tab)
 

--- a/docs/main/BasicClient/Interactions.md
+++ b/docs/main/BasicClient/Interactions.md
@@ -33,8 +33,8 @@ Interaction Commands fall into three broad categories:
 Every mouse command include a [`MousePosition`](#mouseposition) value, which specifies where the interaction takes place. It accepts three possible options:
 
 - `[x, y]` These are pixels relative to the top-left corner of the viewport.
-- [`SuperElement`](/docs/awaited-dom/super-element) Any element from the AwaitedDOM, which are translated into x/y coordinates.
-- { element: [`SuperElement`](/docs/awaited-dom/super-element), verification: [`ClickVerification`](#clickverification) } An element with a specified click verification strategy.
+- [`SuperElement`](/docs/hero/awaited-dom/super-element) Any element from the AwaitedDOM, which are translated into x/y coordinates.
+- { element: [`SuperElement`](/docs/hero/awaited-dom/super-element), verification: [`ClickVerification`](#clickverification) } An element with a specified click verification strategy.
 - `null` Leave the mouse in its current position.
 
 For example, here's how to hover over a link:
@@ -60,17 +60,17 @@ hero.interact({ clickRight: [55, 42] });
 
 #### **ClickVerification**: {#click-verification}
 
-Click commands can include a click verification when a [`SuperElement`](/docs/awaited-dom/super-element) is provided as the `MousePosition`. This is the strategy used to confirm that a specific element is clicked after scrolling and moving the mouse over the target. The default verification is `elementAtPath` if none is provided.
+Click commands can include a click verification when a [`SuperElement`](/docs/hero/awaited-dom/super-element) is provided as the `MousePosition`. This is the strategy used to confirm that a specific element is clicked after scrolling and moving the mouse over the target. The default verification is `elementAtPath` if none is provided.
 
 The web has evolved to include sites where "Elements" on some sites are swapped in and out many times as the site is rendered with new data (think React, Vue, Svelte, etc).
 
-During a normal interaction, the [`SuperElement`](/docs/awaited-dom/super-element) will be looked up at the beginning of the operation to confirm location and current visibility/clickability. Verification that the given element was actually clicked are:
+During a normal interaction, the [`SuperElement`](/docs/hero/awaited-dom/super-element) will be looked up at the beginning of the operation to confirm location and current visibility/clickability. Verification that the given element was actually clicked are:
 
 - `exactElement`. This verification strategy checks that the original node is clicked. This works on most sites, but can fail on dynamic sites, or where data is updating the site (eg, a select list being updated by your type interactions).
-- `elementAtPath` Default Option. This verification approach will first check `exactElement`. If the original element is no longer attached or visible, it will re-check the full path to the [`SuperElement`](/docs/awaited-dom/super-element) and click on any refreshed node.
+- `elementAtPath` Default Option. This verification approach will first check `exactElement`. If the original element is no longer attached or visible, it will re-check the full path to the [`SuperElement`](/docs/hero/awaited-dom/super-element) and click on any refreshed node.
 - `none`. Do not verify clicks. This approach will scroll and click on the last known position of the element - eg, you ran [`hero.getComputedVisibility *(element)*`](/docs/hero/basic-client/hero#get-computed-visibility) or `element.getBoundingClientRect()`. If the position hasn't been previously looked up, it will be looked up once during the interact command. The position of the element will be used to scroll, move the mouse and click.
 
-Verification strategies can be provided to click/doubleclick commands with a [`SuperElement`](/docs/awaited-dom/super-element) as the `MousePosition`. If you don't provide a verification strategy, `elementAtPath` will be used by default.
+Verification strategies can be provided to click/doubleclick commands with a [`SuperElement`](/docs/hero/awaited-dom/super-element) as the `MousePosition`. If you don't provide a verification strategy, `elementAtPath` will be used by default.
 
 ```js
 const aElem = hero.document.querySelector('a.more-information');


### PR DESCRIPTION
Some paths in the documentation are wrong and result in broken urls.
This PR fixes these paths and has been confirmed to work when building locally.

Example found on https://ulixee.org/docs/hero/basic-client/tab:
- [SuperDocument](https://ulixee.org/docs/awaited-dom/super-document)
Should be:
- [SuperDocument](https://ulixee.org/docs/hero/awaited-dom/super-document)