### PR TITLE
fix: disable auto-shutdown of idle connections

### DIFF
--- a/core/index.ts
+++ b/core/index.ts
@@ -69,6 +69,7 @@ export default class Core {
 
   public static allowDynamicPluginLoading = true;
   public static isClosing: Promise<void>;
+  public static clearIdleConnectionsAfterMillis = -1;
 
   private static isStarting = false;
   private static didRegisterSignals = false;
@@ -83,8 +84,11 @@ export default class Core {
 
   public static addConnection(transportToClient?: ITransportToClient<any>): ConnectionToHeroClient {
     transportToClient ??= new EmittingTransportToClient();
-    const connection = new ConnectionToHeroClient(transportToClient);
-    connection.on('disconnected', () => this.connections.delete(connection));
+    const connection = new ConnectionToHeroClient(
+      transportToClient,
+      this.clearIdleConnectionsAfterMillis,
+    );
+    connection.once('disconnected', () => this.connections.delete(connection));
     this.connections.add(connection);
     return connection;
   }

--- a/end-to-end/test/basic.test.ts
+++ b/end-to-end/test/basic.test.ts
@@ -1,6 +1,8 @@
 import { Helpers, Hero } from '@ulixee/hero-testing';
-import Resource from '@ulixee/hero/lib/Resource';
-import { Session } from '@ulixee/hero-core';
+import HeroCore, { Session } from '@ulixee/hero-core';
+
+import TransportBridge from '@ulixee/net/lib/TransportBridge';
+import HeroClient, { ConnectionToHeroCore } from '@ulixee/hero';
 
 let koaServer;
 beforeAll(async () => {
@@ -20,112 +22,40 @@ describe('basic Full Client tests', () => {
     expect(url).toBe(koaServer.baseHost);
   });
 
+  it("doesn't automatically close an idle connection", async () => {
+    const bridge = new TransportBridge();
+    const connectionToCore = new ConnectionToHeroCore(bridge.transportToCore);
+    HeroCore.addConnection(bridge.transportToClient);
+    Helpers.onClose(() => connectionToCore.disconnect());
+    const disconnectSpy = jest.spyOn(connectionToCore, 'disconnect');
+
+    const heros: HeroClient[] = [];
+    for (let i = 0; i <= 3; i += 1) {
+      const hero = new HeroClient({ connectionToCore });
+      heros.push(hero);
+      Helpers.needsClosing.push(hero);
+      await hero.goto(koaServer.baseUrl);
+      await hero.waitForLoad('DomContentLoaded');
+    }
+
+    await Promise.all(heros.map(x => x.close()));
+
+    await new Promise(resolve => setTimeout(resolve, 600));
+    expect(disconnectSpy).toHaveBeenCalledTimes(0)
+
+    const hero = new HeroClient({ connectionToCore });
+    heros.push(hero);
+    Helpers.needsClosing.push(hero);
+    await expect(hero.goto(koaServer.baseUrl)).resolves.toBeTruthy();
+    await hero.waitForLoad('DomContentLoaded');
+    await hero.close();
+    expect(disconnectSpy).toHaveBeenCalledTimes(0);
+  });
+
   it('can provide a sessionId', async () => {
     const hero = new Hero({ sessionId: 'session1' });
     Helpers.needsClosing.push(hero);
     expect(await hero.sessionId).toBe('session1');
-  });
-
-  it('allows you to block resources', async () => {
-    koaServer.get('/block', ctx => {
-      ctx.body = `<html>
-<head>
-  <link rel="stylesheet" href="/test.css" />
-</head>
-<body>
-  <img src="/img.png" alt="Image"/>
-</body>
-</html>`;
-    });
-
-    koaServer.get('/img.png', ctx => {
-      ctx.statusCode = 500;
-    });
-    koaServer.get('/test.css', ctx => {
-      ctx.statusCode = 500;
-    });
-
-    const hero = new Hero({
-      blockedResourceTypes: ['BlockAssets'],
-    });
-    Helpers.needsClosing.push(hero);
-
-    const resources: Resource[] = [];
-    await hero.activeTab.on('resource', event => resources.push(event as any));
-    await hero.goto(`${koaServer.baseUrl}/block`);
-    await hero.waitForPaintingStable();
-    await new Promise(setImmediate);
-    expect(resources).toHaveLength(1);
-    expect(await resources[0].response.statusCode).toBe(200);
-    expect(resources[0].type).toBe('Document');
-  });
-
-  it('allows you to block urls: strings', async () => {
-    koaServer.get('/block-strings', ctx => {
-      ctx.body = `<html>
-<head>
-  <link rel="stylesheet" href="/foo/bar/42.css?x=foo&y=%20baz" />
-</head>
-<body>
-  <img src="/baz/bar.png" alt="Image"/>
-</body>
-</html>`;
-    });
-
-    koaServer.get('/foo/bar/42.css?x=foo&y=%20baz', ctx => {
-      ctx.statusCode = 500;
-    });
-    koaServer.get('/baz/bar.png', ctx => {
-      ctx.statusCode = 500;
-    });
-
-    const hero = new Hero({
-      blockedResourceUrls: ['42.css?x=foo', '/baz/'],
-    });
-    Helpers.needsClosing.push(hero);
-
-    const resources: Resource[] = [];
-    await hero.activeTab.on('resource', event => resources.push(event as any));
-    await hero.goto(`${koaServer.baseUrl}/block-strings`);
-    await hero.waitForPaintingStable();
-    await new Promise(setImmediate);
-    expect(resources).toHaveLength(1);
-    expect(await resources[0].response.statusCode).toBe(200);
-    expect(resources[0].type).toBe('Document');
-  });
-
-  it('allows you to block urls: RegExp', async () => {
-    koaServer.get('/block-regexes', ctx => {
-      ctx.body = `<html>
-<head>
-  <link rel="stylesheet" href="/foo/bar/42.css?x=foo&y=%20baz" />
-</head>
-<body>
-  <img src="/baz/bar.png" alt="Image"/>
-</body>
-</html>`;
-    });
-
-    koaServer.get('/foo/bar/42.css?x=foo&y=%20baz', ctx => {
-      ctx.statusCode = 500;
-    });
-    koaServer.get('/baz/bar.png', ctx => {
-      ctx.statusCode = 500;
-    });
-
-    const hero = new Hero({
-      blockedResourceUrls: [/.*\?x=foo/, /\/baz\//],
-    });
-    Helpers.needsClosing.push(hero);
-
-    const resources: Resource[] = [];
-    await hero.activeTab.on('resource', event => resources.push(event as any));
-    await hero.goto(`${koaServer.baseUrl}/block-regexes`);
-    await hero.waitForPaintingStable();
-    await new Promise(setImmediate);
-    expect(resources).toHaveLength(1);
-    expect(await resources[0].response.statusCode).toBe(200);
-    expect(resources[0].type).toBe('Document');
   });
 
   it('should get unreachable proxy errors in the client', async () => {
@@ -145,43 +75,6 @@ describe('basic Full Client tests', () => {
     Helpers.needsClosing.push(hero);
     const url = await hero.document.location.host;
     expect(url).toBe('');
-  });
-
-  it('gets the resource back from a goto', async () => {
-    const exampleUrl = `${koaServer.baseUrl}/`;
-    const hero = new Hero({
-      locale: 'en-US,en',
-    });
-    Helpers.needsClosing.push(hero);
-
-    const resource = await hero.goto(exampleUrl);
-    const { request, response } = resource;
-    expect(await request.headers).toMatchObject({
-      Host: koaServer.baseHost,
-      Connection: 'keep-alive',
-      'Upgrade-Insecure-Requests': '1',
-      'User-Agent': expect.any(String),
-      Accept: expect.any(String),
-      'Accept-Encoding': 'gzip, deflate',
-      'Accept-Language': 'en-US,en;q=0.9',
-    });
-    expect(await request.url).toBe(exampleUrl);
-    expect(await request.timestamp).toBeTruthy();
-    expect(await request.method).toBe('GET');
-    expect(await request.postData).toBeNull();
-
-    expect(await response.headers).toMatchObject({
-      'Content-Type': 'text/html; charset=utf-8',
-      'Content-Length': expect.any(String),
-      Date: expect.any(String),
-      Connection: 'keep-alive',
-    });
-    expect(await response.url).toBe(exampleUrl);
-    expect(await response.timestamp).toBeTruthy();
-    expect(await response.remoteAddress).toBeTruthy();
-    expect(await response.statusCode).toBe(200);
-    expect(await response.statusMessage).toBe('OK');
-    expect(await response.text).toMatch('<h1>Example Domain</h1>');
   });
 
   it('can get and set cookies', async () => {

--- a/timetravel/test/DomStateGenerator.test.ts
+++ b/timetravel/test/DomStateGenerator.test.ts
@@ -139,6 +139,7 @@ describe('domStateGenerator', () => {
       await tab.flushDomChanges();
       const startTime = Date.now();
       await tab.getJsValue(`tick(50)`);
+      await tab.flushDomChanges();
       await session.close();
       domStateGenerator.addSession(session.db, tab.id, [startTime, Date.now()]);
     }


### PR DESCRIPTION
A legacy of our old model of automatically shutting down idle connections was still present in ConnectionToHeroClients. I've changed this so that you have to explicitly register that you'd like to disconnect "idle" connections via a Core property. As this behavior is only desirable in a "hosting" situation, I've left it undocumented for now.