### PR TITLE
feat(session): config to delete sessions

### DIFF
--- a/core/lib/Session.ts
+++ b/core/lib/Session.ts
@@ -573,17 +573,14 @@ export default class Session
     this.db.flush();
 
     this.removeAllListeners();
-    const databasePath = `${SessionDb.databaseDir}/${this.id}.db`;
-    const id = this.id;
-    // give the system a second to write to db before clearing
-    setImmediate(db => {
-      try {
-        db.close();
-      } catch (e) {
-        /* no-op */
-      }
-      Session.events.emit('closed', { id, databasePath });
-    }, this.db);
+    try {
+      await this.db.close(this.options.sessionPersistence === false);
+    } catch (e) {
+      /* no-op */
+    }
+
+    const databasePath = this.db.path;
+    Session.events.emit('closed', { id: this.id, databasePath });
   }
 
   public addRemoteEventListener(

--- a/core/test/basic.test.ts
+++ b/core/test/basic.test.ts
@@ -1,4 +1,5 @@
 import { Helpers } from '@ulixee/hero-testing/index';
+import * as Fs from 'fs';
 import Core, { Session } from '../index';
 
 afterEach(Helpers.afterEach);
@@ -29,6 +30,17 @@ describe('basic Core tests', () => {
     await Core.shutdown();
     expect(Core.pool.activeAgentsCount).toBe(0);
     await didClose;
+  });
+
+  it('can delete session databases', async () => {
+    const connection = Core.addConnection();
+    Helpers.onClose(() => connection.disconnect());
+    await connection.connect({ maxConcurrentClientCount: 2 });
+    const { session } = await Session.create({ sessionPersistence: false });
+
+    expect(Fs.existsSync(session.db.path)).toBe(true);
+    await session.close();
+    expect(Fs.existsSync(session.db.path)).toBe(false);
   });
 
   it('can subscribe to Sessions created and closed', async () => {

--- a/core/test/sessionResume.test.ts
+++ b/core/test/sessionResume.test.ts
@@ -220,6 +220,7 @@ async function createSession(
 ): Promise<{ session: Session; tab: Tab }> {
   const meta = await connectionToClient.createSession(options);
   const tab = Session.getTab(meta);
-  Helpers.onClose(() => tab.session.close(true));
+  const session = tab.session;
+  Helpers.onClose(() => session.close(true));
   return { session: tab.session, tab };
 }

--- a/docs/basic-client/hero.md
+++ b/docs/basic-client/hero.md
@@ -88,6 +88,7 @@ const Hero = require('@ulixee/hero-playground');
     - ipLookupService `string`. The URL of an http based IpLookupService. A list of common options can be found in the [Unblocked Plugin](https://github.com/ulixee/unblocked/blob/46e1894b5089660d62ac71c18d601e7c47795447/plugins/default-browser-emulator/lib/helpers/lookupPublicIp.ts#L81).
     - proxyIp `string`. The optional IP address of your proxy, if known ahead of time.
     - publicIp `string`. The optional IP address of your host machine, if known ahead of time.
+  - sessionPersistence `boolean`. Do not save the [Session](../advanced-concepts/sessions.md) database if set to `false`. Defaults to `true` so you can troubleshoot errors, and load/extract data from previous sessions. 
 
 ## Properties
 

--- a/interfaces/ISessionCreateOptions.ts
+++ b/interfaces/ISessionCreateOptions.ts
@@ -7,6 +7,7 @@ export default interface ISessionCreateOptions extends ISessionOptions, IEmulati
   sessionId?: string;
   sessionName?: string;
   sessionKeepAlive?: boolean;
+  sessionPersistence?: boolean;
   resumeSessionId?: string;
   resumeSessionStartLocation?: 'currentLocation' | 'sessionStart';
   replaySessionId?: string;


### PR DESCRIPTION
Add a configuration variable to delete session databases after use per Hero instance. This has been requested frequently. By default, this is not enabled - in particular since we are adding many features to have a full-fledged Hero instance that can run off a prior session, which we believe will change the default way many people use Hero (eg, into a two-phased collect and then extract process).