### PR TITLE
feat(hero): add connected/session created event

### DIFF
--- a/client/interfaces/ICoreSession.ts
+++ b/client/interfaces/ICoreSession.ts
@@ -1,17 +1,20 @@
 import IDataSnippet from '@ulixee/hero-interfaces/IDataSnippet';
 import IDetachedElement from '@ulixee/hero-interfaces/IDetachedElement';
 import IDetachedResource from '@ulixee/hero-interfaces/IDetachedResource';
+import ITypedEventEmitter from '@ulixee/commons/interfaces/ITypedEventEmitter';
 
 // This interface exists for DatastoreInternal to import
 
-export default interface ICoreSession {
+export default interface ICoreSession extends ITypedEventEmitter<{ close: void }> {
   sessionId: string;
   setSnippet(key: string, value: any): Promise<void>;
   getSnippets(sessionId: string, key: string): Promise<IDataSnippet[]>;
-  getCollectedAssetNames(sessionId: string): Promise<{ resources: string[]; elements: string[]; snippets: string[] }>;
+  getCollectedAssetNames(
+    sessionId: string,
+  ): Promise<{ resources: string[]; elements: string[]; snippets: string[] }>;
   getDetachedElements(sessionId: string, name: string): Promise<IDetachedElement[]>;
   getDetachedResources(sessionId: string, name: string): Promise<IDetachedResource[]>;
-  recordOutput(changes: IOutputChangeToRecord[]): void
+  recordOutput(changes: IOutputChangeToRecord[]): void;
 }
 
 export interface IOutputChangeToRecord {

--- a/client/lib/HeroReplay.ts
+++ b/client/lib/HeroReplay.ts
@@ -1,17 +1,33 @@
+import { TypedEventEmitter } from '@ulixee/commons/lib/eventUtils';
 import Hero from './Hero';
 import IHeroReplayCreateOptions from '../interfaces/IHeroReplayCreateOptions';
 import DetachedElements from './DetachedElements';
 import DetachedResources from './DetachedResources';
 import IHeroCreateOptions from '../interfaces/IHeroCreateOptions';
+import { InternalPropertiesSymbol } from './internal';
+import CoreSession from './CoreSession';
 
-export default class HeroReplay {
+export default class HeroReplay extends TypedEventEmitter<{ connected: void }> {
   #hero: Hero;
 
+  get [InternalPropertiesSymbol](): {
+    isConnected: boolean;
+    coreSessionPromise: Promise<CoreSession>;
+  } {
+    return this.#hero[InternalPropertiesSymbol];
+  }
+
   constructor(initializeOptions: IHeroReplayCreateOptions) {
+    super();
     if ('hero' in initializeOptions) {
       this.#hero = initializeOptions.hero;
     } else {
       this.#hero = new Hero(initializeOptions as IHeroCreateOptions);
+    }
+    if (this.#hero[InternalPropertiesSymbol].isConnected) {
+      process.nextTick(this.emit.bind(this, 'connected'));
+    } else {
+      void this.#hero.once('connected', this.emit.bind(this, 'connected'));
     }
   }
 

--- a/core/dbs/SessionsDb.ts
+++ b/core/dbs/SessionsDb.ts
@@ -8,6 +8,7 @@ import Session from '../lib/Session';
 interface IDbOptions {
   readonly?: boolean;
   fileMustExist?: boolean;
+  enableSqliteWAL?: boolean;
 }
 
 export default class SessionsDb {
@@ -19,10 +20,12 @@ export default class SessionsDb {
 
   constructor(dbOptions: IDbOptions = {}) {
     SessionsDb.createDir();
-    const { readonly = false, fileMustExist = false } = dbOptions;
+    const { readonly = false, fileMustExist = false, enableSqliteWAL = false } = dbOptions;
     this.db = new Database(SessionsDb.databasePath, { readonly, fileMustExist });
-    this.db.unsafeMode(false);
-    this.db.pragma('journal_mode = WAL');
+    if (enableSqliteWAL) {
+      this.db.unsafeMode(false);
+      this.db.pragma('journal_mode = WAL');
+    }
     this.readonly = readonly;
     this.sessions = new SessionsTable(this.db);
   }


### PR DESCRIPTION
Add an on connected event for both Hero and HeroReplay that will trigger when the session is connected. Had to create this because the act of "accessing" the coreSessionPromise was creating the session before, which meant you couldn't then use plugins.