### PR TITLE
Update date types for SocketsTable.ts

### DIFF
--- a/core/models/SocketsTable.ts
+++ b/core/models/SocketsTable.ts
@@ -72,13 +72,13 @@ export interface ISocketRecord {
   dnsResolvedIp: string;
   alpn: string;
   serverName: string;
-  createTime: Date;
-  dnsLookupTime: Date;
-  ipcConnectionTime: Date;
-  connectTime: Date;
+  createTime: number;
+  dnsLookupTime: number;
+  ipcConnectionTime: number;
+  connectTime: number;
   bytesRead: number;
   bytesWritten: number;
-  errorTime: Date;
-  closeTime: Date;
+  errorTime: number;
+  closeTime: number;
   connectError?: string;
 }


### PR DESCRIPTION
These types are incorrect. In reality they are epoch (ms) timestamps, making it now a bit had to use them (e.g. need to now use `as unknown as number` from within a Ts codebase).