### PR TITLE
feat: expose triggerFlowHandler internal data

### DIFF
--- a/client/lib/FlowCommand.ts
+++ b/client/lib/FlowCommand.ts
@@ -67,8 +67,8 @@ export default class FlowCommand<T= void> implements IFlowCommand {
 
         if (this.isFlowStateChanged) continue;
         // if not complete, trigger flow handlers to retry (catch will trigger on its own)
-        const shouldRetry = await this.coreTab.triggerFlowHandlers();
-
+        const { triggeredFlowHandler } = await this.coreTab.triggerFlowHandlers();
+        const shouldRetry = triggeredFlowHandler !== undefined
         if (!shouldRetry) {
           throw new Error(
             'The FlowCommand cannot be completed. The Exit State is not satisfied and no FlowHandlers were triggered.',

--- a/client/lib/Hero.ts
+++ b/client/lib/Hero.ts
@@ -590,7 +590,7 @@ export default class Hero extends AwaitedEventTarget<IHeroEvents> {
     return await this.activeTab.registerFlowHandler(name, state, handlerCallbackFn);
   }
 
-  public async triggerFlowHandlers(): Promise<void> {
+  public async triggerFlowHandlers(): Promise<{triggeredFlowHandler?: string; matchedFlowHandlers: string[]}> {
     return await this.activeTab.triggerFlowHandlers();
   }
 

--- a/client/lib/Tab.ts
+++ b/client/lib/Tab.ts
@@ -294,9 +294,13 @@ export default class Tab extends AwaitedEventTarget<IEventType> {
     await coreTab.registerFlowHandler(name, state, handlerFn, callsitePath);
   }
 
-  public async triggerFlowHandlers(): Promise<void> {
+  public async triggerFlowHandlers(): Promise<{triggeredFlowHandler?: string; matchedFlowHandlers: string[]}> {
     const coreTab = await this.#coreTabPromise;
-    await coreTab.triggerFlowHandlers();
+    const coreResult = await coreTab.triggerFlowHandlers()
+    return {
+      triggeredFlowHandler: coreResult.triggeredFlowHandler?.name,
+      matchedFlowHandlers: coreResult.matchedFlowHandlers.map((handler) => handler.name),
+    };
   }
 
   public async flowCommand<T = void>(

--- a/client/lib/Tab.ts
+++ b/client/lib/Tab.ts
@@ -296,7 +296,7 @@ export default class Tab extends AwaitedEventTarget<IEventType> {
 
   public async triggerFlowHandlers(): Promise<{triggeredFlowHandler?: string; matchedFlowHandlers: string[]}> {
     const coreTab = await this.#coreTabPromise;
-    const coreResult = await coreTab.triggerFlowHandlers()
+    const coreResult = await coreTab.triggerFlowHandlers();
     return {
       triggeredFlowHandler: coreResult.triggeredFlowHandler?.name,
       matchedFlowHandlers: coreResult.matchedFlowHandlers.map((handler) => handler.name),

--- a/docs/advanced-client/tab.md
+++ b/docs/advanced-client/tab.md
@@ -439,9 +439,9 @@ Takes a screenshot of the current contents rendered in the browser.
 
 ### tab.triggerFlowHandlers *()* {#trigger-flow-handler}
 
-Check the state of all [FlowHandlers](#register-flow-handler) and trigger them to run if they match the current page state.
+Check the state of all [FlowHandlers](#register-flow-handler) and trigger the first one that matches the current page state. Returns the name of the triggered FlowHandler (if one was triggered), and returns the names of all FlowHandler who's state match the current page state.
 
-#### **Returns**: `Promise<void>`
+#### **Returns**: `Promise<{triggeredFlowHandler?: string; matchedFlowHandlers: string[]}>`
 
 ### tab.validateState *(state)* {#validate-state}
 

--- a/end-to-end/test/flow.test.ts
+++ b/end-to-end/test/flow.test.ts
@@ -80,7 +80,7 @@ test('can handle multiple simultaneous handlers', async () => {
     () => Promise.resolve(),
   );
 
-  await expect(hero.activeTab.triggerFlowHandlers()).resolves.toBe(undefined);
+  await expect(hero.activeTab.triggerFlowHandlers()).resolves.toHaveProperty('matchedFlowHandlers');
 });
 
 test('bubbles up handler errors to the line of code that triggers the handlers', async () => {


### PR DESCRIPTION
Expose 'triggeredFlowHandler', and 'matchedFlowHandlers' to caller so he knows what hero did when called manually. 
This function can also now be called multiple times as long as hero is making progress (matchedFlowHandlers is shrinking). 