### PR TITLE
fix: sync core ES exports with TS exports

### DIFF
--- a/core/index.mjs
+++ b/core/index.mjs
@@ -1,6 +1,6 @@
 import cjsImport from './index.js';
 
-const { BrowserEmulators, HumanEmulators } = cjsImport;
+const { Tab, Session, LocationTrigger } = cjsImport;
 
-export { BrowserEmulators, HumanEmulators };
+export { Tab, Session, LocationTrigger };
 export default cjsImport.default;


### PR DESCRIPTION
Fix missing named exports for `hero-core`. Replacing copied exports copied from unlocked.Browser/Human with actual core exports.