### PR TITLE
Fix frameId data type in frame-environment.md

### DIFF
--- a/docs/advanced-client/frame-environment.md
+++ b/docs/advanced-client/frame-environment.md
@@ -30,7 +30,7 @@ Returns a reference to the document of the frameEnvironment.
 
 An identifier for the frameEnvironment.
 
-#### **Type**: `Promise<string>`
+#### **Type**: `Promise<number>`
 
 ### frameEnvironment.isAllContentLoaded {#is-all-content-loaded}
 


### PR DESCRIPTION
In docs the `FrameEnvironment.frameId` is described as `string` but in the class definition it is `number`.

This PR change the data type in doc to `number`, so it conforms to the reality.