### PR TITLE
Callbacks for NewDocumentScripts

### DIFF
--- a/agent/docs/Page.md
+++ b/agent/docs/Page.md
@@ -89,29 +89,21 @@ Shortcut to type a string of text.
 
 - text `string`. Text characters to type.
 
-### addNewDocumentScript(script, isolateFromWebpage): Promise<{ identifier:string }>
+### addNewDocumentScript(script, isolateFromWebpage, callbacks): Promise<{ identifier:string }>
 
-Add a new script to run on all new Frames created from this Page, as well as before any new Navigations are completed on the main [Frame](./Frame.md). Returns an identifier that can be uninstalled by passing to `page.removeDocumentScript`. These scripts also have a `callback(name: string, payload: string)` injected, which they can use to send data to nodejs, see `addPageCallback` for how to listen to this callback.
+Add a new script to run on all new Frames created from this Page, as well as before any new Navigations are completed on the main [Frame](./Frame.md). Returns an identifier that can be uninstalled by passing to `page.removeDocumentScript`. These scripts optionally can have a `callbackFn` that can be provided. The first parameter will be the returned identifier.
 
 #### **Arguments**:
 
 - script `string`. The script to run
 - isolateFromWebpage `boolean`. Should this script run in the same Javascript memory as the main webpage, or should it be isolated. NOTE: to manipulate the default DOM objects and methods, you must set this flag to `false`. Defaults to `true`.
+- callbacks `object`. Optional callback function details
+  - \<key\> `string`. The name of the callback function
+  - \<value\> `(identifier: string, frameId: string) => void` Optional callback to trigger when this Page Binding is triggered. Will also emit the event `page-callback-triggered`.
 
 ### removeDocumentScript(scriptId): Promise<void>
 
 Uninstall a newDocumentScript. NOTE: this will not un-do anything ran on the current Page + Frames.
-
-#### **Arguments**:
-
-### addPageCallback(name, onCallbackFn): Promise<RegisteredEventListener>
-
-All scripts added by addNewDocumentScript have a callback function injected in them. This "function" can be called from in-Page javascript back to Node.js. By calling addPageCallback with the same name as used in the page script you can subscribe to these callbacks and run onCallbackFn.
-
-#### **Arguments**:
-
-- name `string`. The name used when running `callback(name, payload)` from within a page script.
-- onCallbackFn `(payload: string, frameId: string) => void` A callback to trigger when this Page Binding is triggered.
 
 ### setJavaScriptEnabled(enabled): Promise<void>
 

--- a/agent/main/lib/BrowserContext.ts
+++ b/agent/main/lib/BrowserContext.ts
@@ -327,7 +327,7 @@ export default class BrowserContext
     try {
       const logId = this.logger.info('BrowserContext.Closing');
       for (const waitingPage of this.waitForPageAttachedById.values()) {
-        await waitingPage.reject(new CanceledPromiseError('BrowserContext shutting down'), true);
+        waitingPage.reject(new CanceledPromiseError('BrowserContext shutting down'), true);
       }
       if (this.browser.devtoolsSession.isConnected()) {
         await Promise.all([...this.pagesById.values()].map(x => x.close()));

--- a/agent/main/lib/InjectedScripts.ts
+++ b/agent/main/lib/InjectedScripts.ts
@@ -1,8 +1,8 @@
 import * as fs from 'fs';
 import { stringifiedTypeSerializerClass } from '@ulixee/commons/lib/TypeSerializer';
-import { IDomPaintEvent } from '@ulixee/unblocked-specification/agent/browser/Location';
 import FramesManager from './FramesManager';
 import DevtoolsSession from './DevtoolsSession';
+import { TNewDocumentCallbackFn } from '@ulixee/unblocked-specification/agent/browser/IPage';
 
 const pageScripts = {
   NodeTracker: fs.readFileSync(`${__dirname}/../injected-scripts/NodeTracker.js`, 'utf8'),
@@ -35,19 +35,14 @@ export default class InjectedScripts {
   public static install(
     framesManager: FramesManager,
     devtoolsSession: DevtoolsSession,
-    onPaintEvent: (
-      frameId: number,
-      event: { url: string; event: IDomPaintEvent; timestamp: number },
-    ) => void,
+    onPaintEvent: TNewDocumentCallbackFn,
   ): Promise<any> {
     return Promise.all([
       framesManager.addNewDocumentScript(
         injectedScript,
         framesManager.page.installJsPathIntoIsolatedContext,
         {
-          [pageEventsCallbackName](payload: string, frame): void {
-            onPaintEvent(frame.frameId, JSON.parse(payload));
-          },
+          [pageEventsCallbackName]: onPaintEvent,
         },
         devtoolsSession,
       ),

--- a/agent/main/lib/InjectedScripts.ts
+++ b/agent/main/lib/InjectedScripts.ts
@@ -11,7 +11,7 @@ const pageScripts = {
   PaintEvents: fs.readFileSync(`${__dirname}/../injected-scripts/PaintEvents.js`, 'utf8'),
 };
 
-const pageEventsCallbackName = '__ulxPagePaintEventListenerCallback';
+const pageEventsCallbackName = 'onPaintEvent';
 export const injectedScript = `(function ulxInjectedScripts(callbackName) {
 const exports = {}; // workaround for ts adding an exports variable
 ${stringifiedTypeSerializerClass};
@@ -41,13 +41,14 @@ export default class InjectedScripts {
     ) => void,
   ): Promise<any> {
     return Promise.all([
-      framesManager.addPageCallback(
-        pageEventsCallbackName,
-        (payload, frame) => onPaintEvent(frame.frameId, JSON.parse(payload)),
-      ),
       framesManager.addNewDocumentScript(
         injectedScript,
         framesManager.page.installJsPathIntoIsolatedContext,
+        {
+          [pageEventsCallbackName](payload: string, frame): void {
+            onPaintEvent(frame.frameId, JSON.parse(payload));
+          },
+        },
         devtoolsSession,
       ),
     ]);

--- a/agent/main/lib/Page.ts
+++ b/agent/main/lib/Page.ts
@@ -16,7 +16,6 @@
  */
 import { IBoundLog } from '@ulixee/commons/interfaces/ILog';
 import { CanceledPromiseError } from '@ulixee/commons/interfaces/IPendingWaitEvent';
-import IRegisteredEventListener from '@ulixee/commons/interfaces/IRegisteredEventListener';
 import EventSubscriber from '@ulixee/commons/lib/EventSubscriber';
 import { TypedEventEmitter } from '@ulixee/commons/lib/eventUtils';
 import Timer from '@ulixee/commons/lib/Timer';
@@ -235,33 +234,21 @@ export default class Page extends TypedEventEmitter<IPageLevelEvents> implements
   addNewDocumentScript(
     script: string,
     isolatedEnvironment: boolean,
+    callbacks?: { [name: string]: (payload: string, frame: IFrame) => any | null },
     devtoolsSession?: DevtoolsSession,
   ): Promise<{ identifier: string }> {
-    return this.framesManager.addNewDocumentScript(script, isolatedEnvironment, devtoolsSession);
+    return this.framesManager.addNewDocumentScript(
+      script,
+      isolatedEnvironment,
+      callbacks,
+      devtoolsSession,
+    );
   }
 
   removeDocumentScript(identifier: string, devtoolsSession?: DevtoolsSession): Promise<void> {
     return (devtoolsSession ?? this.devtoolsSession).send(
       'Page.removeScriptToEvaluateOnNewDocument',
       { identifier },
-    );
-  }
-
-  addPageCallback(
-    name: string,
-    onCallback?: (payload: string, frame: IFrame) => any,
-  ): Promise<IRegisteredEventListener> {
-    return this.framesManager.addPageCallback(
-      name,
-      (payload, frame) => {
-        if (onCallback) onCallback(payload, frame);
-
-        this.emit('page-callback-triggered', {
-          name,
-          payload,
-          frameId: frame.frameId,
-        });
-      },
     );
   }
 

--- a/agent/main/lib/Page.ts
+++ b/agent/main/lib/Page.ts
@@ -25,7 +25,11 @@ import IDialog from '@ulixee/unblocked-specification/agent/browser/IDialog';
 import IExecJsPathResult from '@ulixee/unblocked-specification/agent/browser/IExecJsPathResult';
 import { IFrame } from '@ulixee/unblocked-specification/agent/browser/IFrame';
 import INavigation from '@ulixee/unblocked-specification/agent/browser/INavigation';
-import { IPage, IPageEvents } from '@ulixee/unblocked-specification/agent/browser/IPage';
+import {
+  IPage,
+  IPageEvents,
+  TNewDocumentCallbackFn,
+} from '@ulixee/unblocked-specification/agent/browser/IPage';
 import IScreenshotOptions from '@ulixee/unblocked-specification/agent/browser/IScreenshotOptions';
 import { ILoadStatus, LoadStatus } from '@ulixee/unblocked-specification/agent/browser/Location';
 import {
@@ -234,7 +238,7 @@ export default class Page extends TypedEventEmitter<IPageLevelEvents> implements
   addNewDocumentScript(
     script: string,
     isolatedEnvironment: boolean,
-    callbacks?: { [name: string]: (payload: string, frame: IFrame) => any | null },
+    callbacks?: { [name: string]: TNewDocumentCallbackFn | null },
     devtoolsSession?: DevtoolsSession,
   ): Promise<{ identifier: string }> {
     return this.framesManager.addNewDocumentScript(

--- a/agent/main/lib/WebsocketMessages.ts
+++ b/agent/main/lib/WebsocketMessages.ts
@@ -71,9 +71,6 @@ export default class WebsocketMessages extends TypedEventEmitter<{
     isMitmEnabled: boolean,
   ): IWebsocketMessage | undefined {
     if (!event.resourceId && isMitmEnabled) {
-      this.logger.error(`CaptureWebsocketMessageError.UnregisteredResource`, {
-        event,
-      });
       return;
     }
 

--- a/agent/main/lib/WebsocketSession.ts
+++ b/agent/main/lib/WebsocketSession.ts
@@ -167,11 +167,8 @@ function injectedScript(): void {
   const url = `${this.host}:${this.port}?secret=${this.secret}&clientId=${clientId}`;
   // This will signal to network manager we are trying to make websocket connection
   // This is needed later to map clientId to frameId
-  fetch(`http://${url}`, {
-    mode: 'no-cors',
-  })
-    // eslint-disable-next-line no-console
-    .catch(error => console.log(error));
+  fetch(`http://${url}`).catch(() => {});
+
   let callback: WebsocketCallback;
   try {
     const socket = new WebSocket(`ws://${url}`);

--- a/agent/main/lib/WebsocketSession.ts
+++ b/agent/main/lib/WebsocketSession.ts
@@ -167,8 +167,11 @@ function injectedScript(): void {
   const url = `${this.host}:${this.port}?secret=${this.secret}&clientId=${clientId}`;
   // This will signal to network manager we are trying to make websocket connection
   // This is needed later to map clientId to frameId
-  // eslint-disable-next-line no-console
-  fetch(`http://${url}`).catch(error => console.log(error));
+  fetch(`http://${url}`, {
+    mode: 'no-cors',
+  })
+    // eslint-disable-next-line no-console
+    .catch(error => console.log(error));
   let callback: WebsocketCallback;
   try {
     const socket = new WebSocket(`ws://${url}`);

--- a/commons/test/utils.test.ts
+++ b/commons/test/utils.test.ts
@@ -14,7 +14,7 @@ test('should not escape already unescaped regex chars', () => {
   expect(result).toBe('http://test.com\\?param=1');
 });
 
-test('should get all functions of an object hierarchy', () => {
+test('should find functions in a class', () => {
   class BaseClass {
     method1() {}
     method2() {}
@@ -25,13 +25,6 @@ test('should get all functions of an object hierarchy', () => {
   }
 
   const instance = new TestClass();
-  const hierarchy = Utils.getPrototypeHierarchy(instance);
-  expect(hierarchy[0]).toEqual(BaseClass.prototype);
-  expect(hierarchy[1]).toEqual(TestClass.prototype);
-  expect(hierarchy[2]).toEqual(instance);
-  // cache should return the same set
-  expect(Utils.getPrototypeHierarchy(instance)).toEqual(hierarchy);
-
   bindFunctions(instance);
 
   expect([...Utils.getObjectFunctionProperties(BaseClass.prototype)]).toEqual([
@@ -39,13 +32,6 @@ test('should get all functions of an object hierarchy', () => {
     'method2',
   ]);
   expect([...Utils.getObjectFunctionProperties(TestClass.prototype)]).toEqual(['method3']);
-
-  // should bind all methods
-  expect([...Utils.getObjectFunctionProperties(instance)]).toEqual([
-    'method1',
-    'method2',
-    'method3',
-  ]);
 });
 
 test('can check Prerelease Semvers', () => {

--- a/core/lib/InjectedScripts.ts
+++ b/core/lib/InjectedScripts.ts
@@ -20,7 +20,7 @@ const pageScripts = {
     'utf8',
   ),
 };
-const pageEventsCallbackName = '__heroPageListenerCallback';
+const pageEventsCallbackName = 'paintEvents';
 
 export const heroIncludes = `
 const exports = {}; // workaround for ts adding an exports variable
@@ -83,10 +83,14 @@ export default class InjectedScripts {
     page[installedSymbol] = true;
 
     return Promise.all([
-      page.addPageCallback(pageEventsCallbackName, null),
-      page.addNewDocumentScript(injectedScript, true, devtoolsSession),
+      page.addNewDocumentScript(
+        injectedScript,
+        true,
+        { [pageEventsCallbackName]: null },
+        devtoolsSession,
+      ),
       showInteractions
-        ? page.addNewDocumentScript(showInteractionScript, true, devtoolsSession)
+        ? page.addNewDocumentScript(showInteractionScript, true, null, devtoolsSession)
         : null,
     ]);
   }

--- a/core/models/DevtoolsMessagesTable.ts
+++ b/core/models/DevtoolsMessagesTable.ts
@@ -2,6 +2,7 @@
 import { Database as SqliteDatabase } from 'better-sqlite3';
 import SqliteTable from '@ulixee/commons/lib/SqliteTable';
 import DevtoolsSessionLogger from '@ulixee/unblocked-agent/lib/DevtoolsSessionLogger';
+import InjectedScripts from '../lib/InjectedScripts';
 
 export default class DevtoolsMessagesTable extends SqliteTable<IDevtoolsMessageRecord> {
   private pageIds = new IdAssigner();
@@ -39,7 +40,7 @@ export default class DevtoolsMessagesTable extends SqliteTable<IDevtoolsMessageR
       if (
         key === 'payload' &&
         method === 'Runtime.bindingCalled' &&
-        params.name === '__heroPageListenerCallback' &&
+        params.name === InjectedScripts.PageEventsCallbackName &&
         value?.length > 250
       ) {
         return `${value.substr(0, 250)}... [truncated ${value.length - 250} chars]`;

--- a/plugins/default-browser-emulator/interfaces/INewDocumentInjectedScript.ts
+++ b/plugins/default-browser-emulator/interfaces/INewDocumentInjectedScript.ts
@@ -1,6 +1,6 @@
-import { IFrame } from '@ulixee/unblocked-specification/agent/browser/IFrame';
+import { TNewDocumentCallbackFn } from '@ulixee/unblocked-specification/agent/browser/IPage';
 
 export default interface INewDocumentInjectedScript {
   script: string;
-  callback?: { name: string; fn: (data: string, frame: IFrame) => void };
+  callback?: { name: string; fn: TNewDocumentCallbackFn | null };
 }

--- a/plugins/default-browser-emulator/interfaces/INewDocumentInjectedScript.ts
+++ b/plugins/default-browser-emulator/interfaces/INewDocumentInjectedScript.ts
@@ -2,5 +2,5 @@ import { IFrame } from '@ulixee/unblocked-specification/agent/browser/IFrame';
 
 export default interface INewDocumentInjectedScript {
   script: string;
-  callback?: { name: string; fn: (data: string, frame: IFrame) => void }
+  callback?: { name: string; fn: (data: string, frame: IFrame) => void };
 }

--- a/plugins/default-browser-emulator/lib/setPageDomOverrides.ts
+++ b/plugins/default-browser-emulator/lib/setPageDomOverrides.ts
@@ -2,6 +2,7 @@ import { IPage } from '@ulixee/unblocked-specification/agent/browser/IPage';
 import IDevtoolsSession from '@ulixee/unblocked-specification/agent/browser/IDevtoolsSession';
 import IBrowserData from '../interfaces/IBrowserData';
 import DomOverridesBuilder from './DomOverridesBuilder';
+import INewDocumentInjectedScript from '../interfaces/INewDocumentInjectedScript';
 
 export default async function setPageDomOverrides(
   domOverrides: DomOverridesBuilder,
@@ -10,12 +11,11 @@ export default async function setPageDomOverrides(
   devtoolsSession?: IDevtoolsSession,
 ): Promise<void> {
   const script = domOverrides.build('page');
-  const promises: Promise<any>[] = [];
+  const callbacks: { [name: string]: INewDocumentInjectedScript['callback']['fn'] } = {};
   for (const { name, fn } of script.callbacks) {
-    promises.push(pageOrFrame.addPageCallback(name, fn));
+    callbacks[name] = fn;
   }
-  // overrides happen in main frame
-  promises.push(pageOrFrame.addNewDocumentScript(script.script, false, devtoolsSession));
 
-  await Promise.all(promises);
+  // overrides happen in main frame
+  await pageOrFrame.addNewDocumentScript(script.script, false, callbacks, devtoolsSession);
 }

--- a/specification/agent/browser/IPage.ts
+++ b/specification/agent/browser/IPage.ts
@@ -1,4 +1,3 @@
-import type IRegisteredEventListener from '@ulixee/commons/interfaces/IRegisteredEventListener';
 import type ITypedEventEmitter from '@ulixee/commons/interfaces/ITypedEventEmitter';
 import { IJsPath } from '@ulixee/js-path';
 import { IFrame, IFrameManagerEvents } from './IFrame';
@@ -43,13 +42,10 @@ export interface IPage extends ITypedEventEmitter<IPageEvents> {
   addNewDocumentScript(
     script: string,
     isolateFromWebPageEnvironment: boolean,
+    callbackFns?: { [name: string]: (payload: string, frame: IFrame) => any | null },
     devtoolsSession?: IDevtoolsSession,
   ): Promise<{ identifier: string }>;
   removeDocumentScript(identifier: string, devtoolsSession?: IDevtoolsSession): Promise<void>;
-  addPageCallback(
-    name: string,
-    onCallback?: (payload: string, frame: IFrame) => any,
-  ): Promise<IRegisteredEventListener>;
 }
 
 export interface IPageEvents extends IFrameManagerEvents, IBrowserNetworkEvents {

--- a/specification/agent/browser/IPage.ts
+++ b/specification/agent/browser/IPage.ts
@@ -42,11 +42,15 @@ export interface IPage extends ITypedEventEmitter<IPageEvents> {
   addNewDocumentScript(
     script: string,
     isolateFromWebPageEnvironment: boolean,
-    callbackFns?: { [name: string]: (payload: string, frame: IFrame) => any | null },
+    callbackFns?: {
+      [name: string]: TNewDocumentCallbackFn | null;
+    },
     devtoolsSession?: IDevtoolsSession,
   ): Promise<{ identifier: string }>;
   removeDocumentScript(identifier: string, devtoolsSession?: IDevtoolsSession): Promise<void>;
 }
+
+export type TNewDocumentCallbackFn = (payload: string, frame: IFrame) => Promise<void> | void;
 
 export interface IPageEvents extends IFrameManagerEvents, IBrowserNetworkEvents {
   close: void;

--- a/timetravel/lib/MirrorNetwork.ts
+++ b/timetravel/lib/MirrorNetwork.ts
@@ -67,7 +67,8 @@ export default class MirrorNetwork {
         responseCode: 200,
         responseHeaders: [
           { name: 'Content-Type', value: 'text/html; charset=utf-8' },
-          { name: 'Content-Security-Policy', value: "script-src 'nonce-hero-timetravel'" },
+          { name: 'Content-Security-Policy', value: "script-src 'nonce-hero-timetravel'; connect-src 'self' ws://websocket.localhost:* http://websocket.localhost:*" },
+          { name: 'Access-Control-Allow-Origin', value: '*' },
         ],
         body: Buffer.from(`${doctype}<html><head></head><body></body></html>`).toString('base64'),
       };


### PR DESCRIPTION
This PR merges the concepts of adding new document scripts with adding callbacks to the page. A few other small changes of note:
1. Added no-cors to the websocket callback
2. Only add the websocket when a callback is present (they're scoped to the fn, so it shouldn't have any impact)
3. Add some csp headers to time travel (needed for electron)