### PR TITLE
Solve ReferenceError: Cookie is not defined

### DIFF
--- a/agent/main/lib/Resources.ts
+++ b/agent/main/lib/Resources.ts
@@ -656,6 +656,7 @@ export default class Resources
     if (!Array.isArray(setCookie)) setCookie = [setCookie];
     const defaultDomain = responseEvent.url.host;
     for (const cookieHeader of setCookie) {
+      if (cookieHeader === '') continue;
       const cookie = Cookie.parse(cookieHeader, { loose: true });
       let domain = cookie.domain || defaultDomain;
       // restore stripped leading .


### PR DESCRIPTION
I ran into an issue with a website that had the header: ```{ 'Set-Cookie': '' }```. This was causing the following fatal error every time I tried to call _hero.goto()_:

```
ERROR [hero-core/index] UnhandledRejection { context: {}, sessionId: null, sessionName: undefined } ReferenceError: Cookie is not defined
    at Resources.recordCookies
```

This simple fix resolves the issue and _hero.goto()_ now behaves as expected.