### PR TITLE
Use ubuntu 22 in tests until issue with 24 is fixed

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -19,17 +19,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, windows-latest, ubuntu-latest]
+        os: [macos-13, windows-latest, ubuntu-22.04]
         node-version: [18, 20, 22]
         include:
           - node-version: 20.x
-            os: ubuntu-latest
+            os: ubuntu-22.04
             browser: chrome-130-0
           - node-version: 20.x
-            os: ubuntu-latest
+            os: ubuntu-22.04
             browser: chrome-120-0
           - node-version: 20.x
-            os: ubuntu-latest
+            os: ubuntu-22.04
             browser: chrome-115-0
 
     runs-on: ${{ matrix.os }}
@@ -45,7 +45,7 @@ jobs:
           cache: yarn
 
       - name: Install pcap
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: sudo apt-get install -y libpcap-dev
 
       - name: Chocolatey Install Action
@@ -71,12 +71,12 @@ jobs:
         run: yarn add -W @ulixee/${{ matrix.browser }}
 
       - name: Linux - Apt Install Chrome(s)
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
         working-directory: ./build
         run: sudo $(npx install-browser-deps)
 
       - name: Run Lint
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.node-version == 18 }}
+        if: ${{ matrix.os == 'ubuntu-22.04' && matrix.node-version == 18 }}
         run: NODE_OPTIONS=--max-old-space-size=4096 yarn lint
 
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Check out our [website for more details](https://ulixee.org).
 
 ## Installation
 
+
 You can get a playground started with Hero very quickly. A playground is a one-time use hero instance that will shut down once you've run a single script. This is great for quick scripts or testing.
 
 ```shell script


### PR DESCRIPTION
Github made ubuntu 24 the default for latest-ubuntu. This break ci testing, until that is fixed use ubuntu 22.