### PR TITLE
fix(agent): support callbacks in chrome internal urls

### DIFF
--- a/agent/main/lib/Console.ts
+++ b/agent/main/lib/Console.ts
@@ -115,10 +115,16 @@ export class Console extends TypedEventEmitter<IConsoleEvents> {
 function injectedScript(): void {
   const clientId = Math.random().toString().slice(2, 12);
 
-  const url = `http://hero.localhost/?secretKey=${this.secretKey}&action=registerConsoleClientId&clientId=${clientId}`;
-
   // This will signal to network manager we are trying to make websocket connection
   // This is needed later to map clientId to frameId
+
+  const scheme = location.href.startsWith('chrome://') ? 'data' : 'http'
+  const url = `${scheme}://hero.localhost/?secretKey=${this.secretKey}&action=registerConsoleClientId&clientId=${clientId}`;
+  if (scheme === 'data') {
+    // eslint-disable-next-line no-console
+    console.info('Using fetch with data:// scheme, http:// not supported inside chrome:// urls, ignore fetch errors including data:// scheme')
+  } 
+
   void fetch(url, { mode: 'no-cors' }).catch(() => undefined);
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/agent/main/lib/NetworkManager.ts
+++ b/agent/main/lib/NetworkManager.ts
@@ -116,6 +116,7 @@ export default class NetworkManager extends TypedEventEmitter<IBrowserNetworkEve
 
     const patternsToIntercepts: Fetch.RequestPattern[] = [
       { urlPattern: 'http://hero.localhost/*' },
+      { urlPattern: 'data://hero.localhost/*' },
     ];
     if (this.proxyConnectionOptions?.password) {
       // Pattern needs to match website url (not proxy url), so wildcard is only option we really have here


### PR DESCRIPTION
When using fetch with http scheme inside chrome internal url such as `chrome://version` it breaks the entire window, using a scheme such as data:// or file:// gives an error in console but still allows everything to work