### PR TITLE
Update IPage evaluate function signature to match Page

### DIFF
--- a/specification/agent/browser/IPage.ts
+++ b/specification/agent/browser/IPage.ts
@@ -38,7 +38,7 @@ export interface IPage extends ITypedEventEmitter<IPageEvents> {
 
   setJavaScriptEnabled(enabled: boolean): Promise<void>;
 
-  evaluate<T>(expression: string): Promise<T>;
+  evaluate<T>(expression: string, options?: { timeoutMs?: number; isolatedFromWebPageEnvironment?: boolean }): Promise<T>;
   addNewDocumentScript(
     script: string,
     isolateFromWebPageEnvironment: boolean,


### PR DESCRIPTION
Currently, the TypeScript definition for `evaluate` on IPage does not match the [implementation](https://github.com/ulixee/hero/blob/main/agent/main/lib/Page.ts#L264). This PR updates the function signature.