### PR TITLE
fix(agent): fix proxyConnectionInfo for socks5 URLs

### DIFF
--- a/agent/main/lib/Agent.ts
+++ b/agent/main/lib/Agent.ts
@@ -63,7 +63,11 @@ export default class Agent extends TypedEventEmitter<{ close: void }> {
     if (!this.enableMitm) {
       if (!this.emulationProfile.upstreamProxyUrl) return null;
       const url = new URL(this.emulationProfile.upstreamProxyUrl);
-      return { address: url.origin, username: url.username, password: url.password };
+      return {
+        address: `${url.protocol}//${url.host}`,
+        username: url.username,
+        password: url.password,
+      };
     }
     if (this.isolatedMitm) {
       // don't use password for an isolated mitm proxy


### PR DESCRIPTION
After upgrading to the [v2.0.0-alpha.32](https://github.com/ulixee/hero/releases/tag/v2.0.0-alpha.32) release, I started seeing `net::ERR_PROXY_CONNECTION_FAILED` errors when using a socks5 URL in `upstreamProxyUrl` with mitm disabled. The cause seems to be [99467940](https://github.com/ulixee/hero/commit/99467940232f004d6cc1a22a3755489083c627be) which parses `upstreamProxyUrl` into a `URL` object and then uses the `origin` property as the proxy address. Unfortunately, for URLs with the `socks5` protocol, the origin property is always `null`. This is a simple workaround that constructs the address from the `protocol` and `host` properties instead.