### PR TITLE
fix(core): handle JSON.parse errors in page callback and DevTools handlers

### DIFF
--- a/agent/main/lib/Connection.ts
+++ b/agent/main/lib/Connection.ts
@@ -65,7 +65,17 @@ export class Connection extends TypedEventEmitter<{
 
   private onMessage(message: string): void {
     const timestamp = new Date();
-    const object = JSON.parse(message);
+    let object;
+    try {
+      object = JSON.parse(message);
+    } catch (error) {
+      log.warn('Connection.InvalidMessage', {
+        sessionId: null,
+        message: message.slice(0, 500),
+        error,
+      });
+      return;
+    }
     object.timestamp = timestamp;
     const devtoolsSessionId = object.params?.sessionId;
 

--- a/core/lib/Tab.ts
+++ b/core/lib/Tab.ts
@@ -933,7 +933,19 @@ export default class Tab
         return;
       }
 
-      this.frameEnvironmentsById.get(frameId).onPageRecorderEvents(JSON.parse(payload));
+      let parsedPayload;
+      try {
+        parsedPayload = JSON.parse(payload);
+      } catch (error) {
+        log.warn('Tab.onPageCallback:InvalidPayload', {
+          sessionId: this.sessionId,
+          frameId,
+          payload,
+          error,
+        });
+        return;
+      }
+      this.frameEnvironmentsById.get(frameId).onPageRecorderEvents(parsedPayload);
     }
   }
 


### PR DESCRIPTION
## Summary

Noticed two places where `JSON.parse()` is called on external data without try-catch, which can crash the session if the payload is malformed:

1. **`Tab.onPageCallback()`** in `core/lib/Tab.ts` — `JSON.parse(payload)` is called directly on the page callback event payload from injected scripts. If a page sends a malformed callback (e.g., during a navigation race or from a misbehaving script), the unhandled `SyntaxError` crashes the DOM recorder event handling for that tab. Added try-catch with a warning log that includes the sessionId, frameId, and payload for debugging, matching the existing pattern used in `getElementHtml()` and other methods in the same file.

2. **`Connection.onMessage()`** in `agent/main/lib/Connection.ts` — `JSON.parse(message)` on incoming DevTools WebSocket messages has no error handling. While the protocol typically sends valid JSON, transport issues (partial messages, connection resets mid-frame) can produce malformed data. An unhandled exception here tears down the entire browser connection. Added try-catch with a truncated message log (capped at 500 chars to avoid log bloat), consistent with the existing `log.warn` pattern used for unknown sessions in the same method.

## Test plan

- [ ] Verify malformed page callback payloads are logged and skipped instead of crashing
- [ ] Verify malformed DevTools messages are logged and skipped instead of tearing down the connection
- [ ] Existing tests still pass